### PR TITLE
[codex] Retrigger CI verification after missing push run

### DIFF
--- a/docs/ci-retrigger-2026-05-01.md
+++ b/docs/ci-retrigger-2026-05-01.md
@@ -1,0 +1,6 @@
+# CI retrigger note
+
+This file exists only to force a fresh GitHub Actions run after the latest main commit did not appear in the push checks table.
+
+Created: 2026-05-01
+Purpose: verify `push` and `pull_request` workflows start normally on a fresh branch and PR.


### PR DESCRIPTION
Superseded by PR #3, which contains the actual runtime and CI hardening work. This PR was opened only to retrigger GitHub Actions after a missing push run.