### PR TITLE
[codex] Harden live execution safety cage

### DIFF
--- a/src/superajan12/cli.py
+++ b/src/superajan12/cli.py
@@ -461,7 +461,7 @@ def execution_check(args: argparse.Namespace) -> None:
         approval_ticket=ticket,
         secrets_ready=args.secrets_ready,
     )
-    console.print({"allowed": decision.allowed, "reasons": decision.reasons})
+    console.print({"allowed": decision.allowed, "reasons": decision.reasons, "vetoes": decision.vetoes})
     if not decision.allowed:
         raise SystemExit(1)
 
@@ -470,6 +470,10 @@ def prepare_order(args: argparse.Namespace) -> None:
     guard = ExecutionDecision(
         allowed=args.force_guard,
         reasons=("forced dry-run guard for local test",) if args.force_guard else ("guard not forced",),
+        vetoes=() if args.force_guard else ("guard not forced",),
+        stale_data_locked=False,
+        hard_position_cap_hit=False,
+        cancel_on_disconnect_required=True,
     )
     order = LiveExecutionConnector().prepare_order(
         guard_decision=guard,

--- a/src/superajan12/config.py
+++ b/src/superajan12/config.py
@@ -46,6 +46,19 @@ class Settings(BaseSettings):
     max_reference_price_deviation_bps: float = Field(
         default=75.0, validation_alias="MAX_REFERENCE_PRICE_DEVIATION_BPS"
     )
+    live_stale_data_max_seconds: float = Field(
+        default=15.0, validation_alias="LIVE_STALE_DATA_MAX_SECONDS"
+    )
+    live_disconnect_grace_seconds: float = Field(
+        default=5.0, validation_alias="LIVE_DISCONNECT_GRACE_SECONDS"
+    )
+    live_max_open_positions: int = Field(default=3, validation_alias="LIVE_MAX_OPEN_POSITIONS")
+    live_max_position_notional_usdc: float = Field(
+        default=25.0, validation_alias="LIVE_MAX_POSITION_NOTIONAL_USDC"
+    )
+    live_cancel_on_disconnect_required: bool = Field(
+        default=True, validation_alias="LIVE_CANCEL_ON_DISCONNECT_REQUIRED"
+    )
 
     audit_log_path: Path = Field(default=Path("data/audit/events.jsonl"), validation_alias="AUDIT_LOG_PATH")
     sqlite_path: Path = Field(default=Path("data/superajan12.sqlite3"), validation_alias="SQLITE_PATH")

--- a/src/superajan12/execution_guard.py
+++ b/src/superajan12/execution_guard.py
@@ -11,10 +11,14 @@ from superajan12.safety import SafetyState
 class ExecutionDecision:
     allowed: bool
     reasons: tuple[str, ...]
+    vetoes: tuple[str, ...]
+    stale_data_locked: bool
+    hard_position_cap_hit: bool
+    cancel_on_disconnect_required: bool
 
 
 class ExecutionGuard:
-    """Blocks any live-capable action unless all safety gates pass."""
+    """Block any live-capable action unless all safety gates pass."""
 
     def __init__(self, approval_gate: ManualApprovalGate | None = None) -> None:
         self.approval_gate = approval_gate or ManualApprovalGate()
@@ -25,19 +29,85 @@ class ExecutionGuard:
         safety_state: SafetyState,
         approval_ticket: ApprovalTicket | None = None,
         secrets_ready: bool = False,
+        *,
+        market_data_fresh: bool = True,
+        stale_data_age_seconds: float | None = None,
+        stale_data_max_age_seconds: float | None = None,
+        venue_session_connected: bool = True,
+        cancel_on_disconnect_supported: bool = True,
+        cancel_on_disconnect_required: bool = True,
+        current_open_positions: int = 0,
+        max_open_positions: int | None = None,
+        requested_notional_usdc: float | None = None,
+        max_position_notional_usdc: float | None = None,
+        pre_trade_veto_reasons: tuple[str, ...] | list[str] | None = None,
     ) -> ExecutionDecision:
-        reasons: list[str] = []
+        vetoes: list[str] = []
+        notes: list[str] = []
 
         if mode != "live":
-            return ExecutionDecision(allowed=False, reasons=("live execution disabled outside live mode",))
+            vetoes.append("live execution disabled outside live mode")
 
-        if not safety_state.can_open_new_positions:
-            reasons.append("safe-mode or kill-switch blocks execution")
+        if safety_state.kill_switch:
+            vetoes.append("kill-switch blocks execution")
+        if safety_state.safe_mode:
+            vetoes.append("safe-mode blocks execution")
+        if safety_state.stale_data_lock:
+            vetoes.append("stale-data lock blocks execution")
+        if safety_state.disconnect_lock:
+            vetoes.append("disconnect lock blocks execution")
 
         if not secrets_ready:
-            reasons.append("required secrets are not ready")
+            vetoes.append("required secrets are not ready")
 
         if approval_ticket is None or not self.approval_gate.can_execute(approval_ticket):
-            reasons.append("manual approval missing")
+            vetoes.append("manual approval missing")
 
-        return ExecutionDecision(allowed=not reasons, reasons=tuple(reasons or ["all execution gates passed"]))
+        if not venue_session_connected:
+            vetoes.append("venue session disconnected")
+
+        if cancel_on_disconnect_required and not cancel_on_disconnect_supported:
+            vetoes.append("cancel-on-disconnect is required but unavailable")
+
+        stale_data_locked = False
+        if not market_data_fresh:
+            stale_data_locked = True
+            if stale_data_age_seconds is not None and stale_data_max_age_seconds is not None:
+                vetoes.append(
+                    f"market data stale: {stale_data_age_seconds:.1f}s > {stale_data_max_age_seconds:.1f}s"
+                )
+            else:
+                vetoes.append("market data stale")
+
+        hard_position_cap_hit = False
+        if max_open_positions is not None and current_open_positions >= max_open_positions:
+            hard_position_cap_hit = True
+            vetoes.append("hard open-position cap reached")
+
+        if (
+            requested_notional_usdc is not None
+            and max_position_notional_usdc is not None
+            and requested_notional_usdc > max_position_notional_usdc
+        ):
+            hard_position_cap_hit = True
+            vetoes.append("requested notional exceeds hard position cap")
+
+        if pre_trade_veto_reasons:
+            vetoes.extend(str(reason) for reason in pre_trade_veto_reasons if str(reason).strip())
+
+        if cancel_on_disconnect_required and cancel_on_disconnect_supported:
+            notes.append("cancel-on-disconnect armed")
+        if market_data_fresh:
+            notes.append("market data fresh")
+        if not hard_position_cap_hit:
+            notes.append("position caps within limits")
+
+        reasons = tuple(vetoes if vetoes else notes or ["all execution gates passed"])
+        return ExecutionDecision(
+            allowed=not vetoes,
+            reasons=reasons,
+            vetoes=tuple(vetoes),
+            stale_data_locked=stale_data_locked,
+            hard_position_cap_hit=hard_position_cap_hit,
+            cancel_on_disconnect_required=cancel_on_disconnect_required,
+        )

--- a/src/superajan12/live_connector.py
+++ b/src/superajan12/live_connector.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 
 from superajan12.execution_guard import ExecutionDecision
 
@@ -12,15 +13,115 @@ class PreparedOrder:
     price: float
     size: float
     dry_run: bool
+    cancel_on_disconnect: bool
+    stale_after_seconds: float | None
+    session_id: str | None
+
+
+@dataclass(frozen=True)
+class ExecutionSession:
+    session_id: str
+    connected: bool
+    cancel_on_disconnect_supported: bool
+    cancel_on_disconnect_armed: bool
+    stale_data_locked: bool
+    last_heartbeat_at: datetime
+    disconnect_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class DisconnectResolution:
+    cancel_open_orders: bool
+    activate_kill_switch: bool
+    reasons: tuple[str, ...]
+    session: ExecutionSession
 
 
 class LiveExecutionConnector:
     """Live connector scaffold.
 
-    This class deliberately does not send orders. It only prepares an order shape
-    after the execution guard has approved all gates. A real exchange adapter must
-    be added later in a separate reviewed step.
+    This class deliberately does not send orders. It models session safety,
+    stale-data locks and cancel-on-disconnect behavior before a real exchange
+    adapter is introduced in a separately reviewed step.
     """
+
+    def open_session(
+        self,
+        *,
+        session_id: str,
+        cancel_on_disconnect_supported: bool,
+        cancel_on_disconnect_required: bool = True,
+    ) -> ExecutionSession:
+        return ExecutionSession(
+            session_id=session_id,
+            connected=True,
+            cancel_on_disconnect_supported=cancel_on_disconnect_supported,
+            cancel_on_disconnect_armed=cancel_on_disconnect_supported and cancel_on_disconnect_required,
+            stale_data_locked=False,
+            last_heartbeat_at=datetime.now(timezone.utc),
+        )
+
+    def mark_heartbeat(self, session: ExecutionSession, *, at: datetime | None = None) -> ExecutionSession:
+        timestamp = at or datetime.now(timezone.utc)
+        return ExecutionSession(
+            session_id=session.session_id,
+            connected=session.connected,
+            cancel_on_disconnect_supported=session.cancel_on_disconnect_supported,
+            cancel_on_disconnect_armed=session.cancel_on_disconnect_armed,
+            stale_data_locked=False,
+            last_heartbeat_at=timestamp,
+            disconnect_reason=session.disconnect_reason,
+        )
+
+    def lock_stale_data(
+        self,
+        session: ExecutionSession,
+        *,
+        now: datetime | None = None,
+        stale_after_seconds: float,
+    ) -> ExecutionSession:
+        current = now or datetime.now(timezone.utc)
+        age_seconds = max((current - session.last_heartbeat_at).total_seconds(), 0.0)
+        stale_locked = age_seconds > stale_after_seconds
+        return ExecutionSession(
+            session_id=session.session_id,
+            connected=session.connected,
+            cancel_on_disconnect_supported=session.cancel_on_disconnect_supported,
+            cancel_on_disconnect_armed=session.cancel_on_disconnect_armed,
+            stale_data_locked=stale_locked,
+            last_heartbeat_at=session.last_heartbeat_at,
+            disconnect_reason=session.disconnect_reason,
+        )
+
+    def handle_disconnect(
+        self,
+        session: ExecutionSession,
+        *,
+        reason: str,
+        open_order_count: int,
+    ) -> DisconnectResolution:
+        disconnected = ExecutionSession(
+            session_id=session.session_id,
+            connected=False,
+            cancel_on_disconnect_supported=session.cancel_on_disconnect_supported,
+            cancel_on_disconnect_armed=session.cancel_on_disconnect_armed,
+            stale_data_locked=True,
+            last_heartbeat_at=session.last_heartbeat_at,
+            disconnect_reason=reason,
+        )
+        cancel_open_orders = open_order_count > 0 and session.cancel_on_disconnect_armed
+        activate_kill_switch = not session.cancel_on_disconnect_armed and open_order_count > 0
+        reasons = [reason, "stale-data lock enabled after disconnect"]
+        if cancel_open_orders:
+            reasons.append("cancel-on-disconnect will clear open orders")
+        if activate_kill_switch:
+            reasons.append("kill-switch required because open orders cannot be canceled on disconnect")
+        return DisconnectResolution(
+            cancel_open_orders=cancel_open_orders,
+            activate_kill_switch=activate_kill_switch,
+            reasons=tuple(reasons),
+            session=disconnected,
+        )
 
     def prepare_order(
         self,
@@ -29,11 +130,30 @@ class LiveExecutionConnector:
         side: str,
         price: float,
         size: float,
+        *,
+        session: ExecutionSession | None = None,
+        stale_after_seconds: float | None = None,
     ) -> PreparedOrder:
         if not guard_decision.allowed:
             raise RuntimeError("execution guard blocked order preparation")
+        if session is not None:
+            if not session.connected:
+                raise RuntimeError("execution session disconnected")
+            if session.stale_data_locked:
+                raise RuntimeError("stale-data lock blocks order preparation")
+            if guard_decision.cancel_on_disconnect_required and not session.cancel_on_disconnect_armed:
+                raise RuntimeError("cancel-on-disconnect is not armed")
         if price <= 0 or price >= 1:
             raise ValueError("prediction market price must be between 0 and 1")
         if size <= 0:
             raise ValueError("order size must be positive")
-        return PreparedOrder(market_id=market_id, side=side, price=price, size=size, dry_run=True)
+        return PreparedOrder(
+            market_id=market_id,
+            side=side,
+            price=price,
+            size=size,
+            dry_run=True,
+            cancel_on_disconnect=bool(session and session.cancel_on_disconnect_armed),
+            stale_after_seconds=stale_after_seconds,
+            session_id=None if session is None else session.session_id,
+        )

--- a/src/superajan12/safety.py
+++ b/src/superajan12/safety.py
@@ -8,11 +8,13 @@ from functools import lru_cache
 class SafetyState:
     safe_mode: bool
     kill_switch: bool
+    stale_data_lock: bool
+    disconnect_lock: bool
     reasons: tuple[str, ...]
 
     @property
     def can_open_new_positions(self) -> bool:
-        return not self.safe_mode and not self.kill_switch
+        return not (self.safe_mode or self.kill_switch or self.stale_data_lock or self.disconnect_lock)
 
 
 class SafetyController:
@@ -25,8 +27,12 @@ class SafetyController:
     def __init__(self) -> None:
         self._safe_mode = False
         self._kill_switch = False
+        self._stale_data_lock = False
+        self._disconnect_lock = False
         self._safe_mode_reason: str | None = None
         self._kill_switch_reason: str | None = None
+        self._stale_data_reason: str | None = None
+        self._disconnect_reason: str | None = None
 
     def enable_safe_mode(self, reason: str) -> None:
         self._safe_mode = True
@@ -39,11 +45,37 @@ class SafetyController:
             self._safe_mode = True
             self._safe_mode_reason = "kill-switch enabled"
 
+    def enable_stale_data_lock(self, reason: str) -> None:
+        self._stale_data_lock = True
+        self._stale_data_reason = reason
+
+    def clear_stale_data_lock(self) -> None:
+        self._stale_data_lock = False
+        self._stale_data_reason = None
+
+    def enable_disconnect_lock(self, reason: str) -> None:
+        self._disconnect_lock = True
+        self._disconnect_reason = reason
+        if not self._safe_mode:
+            self._safe_mode = True
+            self._safe_mode_reason = "disconnect lock enabled"
+
+    def clear_disconnect_lock(self) -> None:
+        self._disconnect_lock = False
+        self._disconnect_reason = None
+        if self._safe_mode and self._safe_mode_reason == "disconnect lock enabled":
+            self._safe_mode = False
+            self._safe_mode_reason = None
+
     def clear_safe_mode(self) -> None:
         self._safe_mode = False
         self._kill_switch = False
+        self._stale_data_lock = False
+        self._disconnect_lock = False
         self._safe_mode_reason = None
         self._kill_switch_reason = None
+        self._stale_data_reason = None
+        self._disconnect_reason = None
 
     def disable_kill_switch(self) -> None:
         self._kill_switch = False
@@ -55,12 +87,19 @@ class SafetyController:
     def state(self) -> SafetyState:
         reasons = tuple(
             reason
-            for reason in (self._safe_mode_reason, self._kill_switch_reason)
+            for reason in (
+                self._safe_mode_reason,
+                self._kill_switch_reason,
+                self._stale_data_reason,
+                self._disconnect_reason,
+            )
             if reason
         )
         return SafetyState(
             safe_mode=self._safe_mode,
             kill_switch=self._kill_switch,
+            stale_data_lock=self._stale_data_lock,
+            disconnect_lock=self._disconnect_lock,
             reasons=reasons,
         )
 

--- a/src/superajan12/storage.py
+++ b/src/superajan12/storage.py
@@ -169,6 +169,25 @@ class SQLiteStore:
                     acknowledged_by TEXT NOT NULL,
                     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
                 );
+
+                CREATE TABLE IF NOT EXISTS execution_sessions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id TEXT NOT NULL UNIQUE,
+                    connected INTEGER NOT NULL DEFAULT 1,
+                    cancel_on_disconnect_supported INTEGER NOT NULL DEFAULT 0,
+                    cancel_on_disconnect_armed INTEGER NOT NULL DEFAULT 0,
+                    stale_data_locked INTEGER NOT NULL DEFAULT 0,
+                    disconnect_reason TEXT,
+                    open_order_count INTEGER NOT NULL DEFAULT 0,
+                    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                );
+
+                CREATE TABLE IF NOT EXISTS execution_veto_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    scope TEXT NOT NULL,
+                    veto_json TEXT NOT NULL,
+                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                );
                 """
             )
             for table, column, ddl in (
@@ -197,6 +216,7 @@ class SQLiteStore:
                 ("market_scores", "reference_confidence", "REAL"),
                 ("paper_trade_ideas", "model_probability", "REAL"),
                 ("paper_trade_ideas", "edge", "REAL"),
+                ("execution_sessions", "open_order_count", "INTEGER NOT NULL DEFAULT 0"),
             ):
                 self._ensure_column(conn, table, column, ddl)
 
@@ -496,6 +516,107 @@ class SQLiteStore:
                 return None
             result = dict(row)
             result["acknowledged"] = bool(result.get("acknowledged"))
+            return result
+
+    def save_execution_session(
+        self,
+        *,
+        session_id: str,
+        connected: bool,
+        cancel_on_disconnect_supported: bool,
+        cancel_on_disconnect_armed: bool,
+        stale_data_locked: bool,
+        disconnect_reason: str | None,
+        open_order_count: int,
+    ) -> int:
+        with self.connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO execution_sessions (
+                    session_id, connected, cancel_on_disconnect_supported,
+                    cancel_on_disconnect_armed, stale_data_locked, disconnect_reason,
+                    open_order_count
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(session_id) DO UPDATE SET
+                    connected = excluded.connected,
+                    cancel_on_disconnect_supported = excluded.cancel_on_disconnect_supported,
+                    cancel_on_disconnect_armed = excluded.cancel_on_disconnect_armed,
+                    stale_data_locked = excluded.stale_data_locked,
+                    disconnect_reason = excluded.disconnect_reason,
+                    open_order_count = excluded.open_order_count,
+                    updated_at = CURRENT_TIMESTAMP
+                """,
+                (
+                    session_id,
+                    1 if connected else 0,
+                    1 if cancel_on_disconnect_supported else 0,
+                    1 if cancel_on_disconnect_armed else 0,
+                    1 if stale_data_locked else 0,
+                    disconnect_reason,
+                    open_order_count,
+                ),
+            )
+            row = conn.execute(
+                "SELECT id FROM execution_sessions WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+            if row is None:
+                raise RuntimeError("execution session save failed")
+            return int(row[0])
+
+    def latest_execution_session(self) -> dict[str, object] | None:
+        with self.connect() as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                """
+                SELECT id, session_id, connected, cancel_on_disconnect_supported,
+                       cancel_on_disconnect_armed, stale_data_locked, disconnect_reason,
+                       open_order_count, updated_at
+                FROM execution_sessions
+                ORDER BY id DESC
+                LIMIT 1
+                """
+            ).fetchone()
+            if row is None:
+                return None
+            result = dict(row)
+            for key in (
+                "connected",
+                "cancel_on_disconnect_supported",
+                "cancel_on_disconnect_armed",
+                "stale_data_locked",
+            ):
+                result[key] = bool(result.get(key))
+            return result
+
+    def record_execution_veto(self, *, scope: str, vetoes: tuple[str, ...] | list[str]) -> int:
+        with self.connect() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO execution_veto_events (scope, veto_json)
+                VALUES (?, ?)
+                """,
+                (scope, json.dumps(list(vetoes), ensure_ascii=False)),
+            )
+            return int(cursor.lastrowid)
+
+    def latest_execution_veto(self, scope: str) -> dict[str, object] | None:
+        with self.connect() as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                """
+                SELECT id, scope, veto_json, created_at
+                FROM execution_veto_events
+                WHERE scope = ?
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+                (scope,),
+            ).fetchone()
+            if row is None:
+                return None
+            result = dict(row)
+            result["vetoes"] = json.loads(str(result.pop("veto_json") or "[]"))
             return result
 
     def _insert_scores(self, conn: sqlite3.Connection, scan_id: int, scores: Iterable[MarketScore]) -> None:

--- a/tests/test_capital_and_live_connector.py
+++ b/tests/test_capital_and_live_connector.py
@@ -40,7 +40,14 @@ def test_capital_limit_engine_blocks_large_single_trade() -> None:
 
 def test_live_connector_blocks_when_guard_rejects() -> None:
     connector = LiveExecutionConnector()
-    guard = ExecutionDecision(allowed=False, reasons=("blocked",))
+    guard = ExecutionDecision(
+        allowed=False,
+        reasons=("blocked",),
+        vetoes=("blocked",),
+        stale_data_locked=False,
+        hard_position_cap_hit=False,
+        cancel_on_disconnect_required=True,
+    )
 
     with pytest.raises(RuntimeError):
         connector.prepare_order(guard, market_id="m1", side="YES", price=0.5, size=10)
@@ -48,7 +55,14 @@ def test_live_connector_blocks_when_guard_rejects() -> None:
 
 def test_live_connector_prepares_dry_run_order_when_guard_allows() -> None:
     connector = LiveExecutionConnector()
-    guard = ExecutionDecision(allowed=True, reasons=("all gates passed",))
+    guard = ExecutionDecision(
+        allowed=True,
+        reasons=("all gates passed",),
+        vetoes=(),
+        stale_data_locked=False,
+        hard_position_cap_hit=False,
+        cancel_on_disconnect_required=True,
+    )
 
     order = connector.prepare_order(guard, market_id="m1", side="YES", price=0.5, size=10)
 

--- a/tests/test_execution_guard.py
+++ b/tests/test_execution_guard.py
@@ -1,0 +1,78 @@
+from datetime import datetime, timezone
+
+from superajan12.approval import ManualApprovalGate
+from superajan12.execution_guard import ExecutionGuard
+from superajan12.safety import SafetyState
+
+
+def test_execution_guard_blocks_stale_disconnect_and_position_caps() -> None:
+    gate = ManualApprovalGate()
+    ticket = gate.approve(gate.request("live_execution", "test"), approved_by="operator")
+    guard = ExecutionGuard(gate)
+
+    decision = guard.can_execute(
+        mode="live",
+        safety_state=SafetyState(
+            safe_mode=False,
+            kill_switch=False,
+            stale_data_lock=True,
+            disconnect_lock=True,
+            reasons=("stale data", "disconnect"),
+        ),
+        approval_ticket=ticket,
+        secrets_ready=True,
+        market_data_fresh=False,
+        stale_data_age_seconds=22.0,
+        stale_data_max_age_seconds=15.0,
+        venue_session_connected=False,
+        cancel_on_disconnect_supported=False,
+        cancel_on_disconnect_required=True,
+        current_open_positions=3,
+        max_open_positions=3,
+        requested_notional_usdc=30.0,
+        max_position_notional_usdc=25.0,
+        pre_trade_veto_reasons=("manual pre-trade veto",),
+    )
+
+    assert decision.allowed is False
+    assert decision.stale_data_locked is True
+    assert decision.hard_position_cap_hit is True
+    assert "stale-data lock blocks execution" in decision.vetoes
+    assert "disconnect lock blocks execution" in decision.vetoes
+    assert "cancel-on-disconnect is required but unavailable" in decision.vetoes
+    assert "hard open-position cap reached" in decision.vetoes
+    assert "requested notional exceeds hard position cap" in decision.vetoes
+    assert "manual pre-trade veto" in decision.vetoes
+
+
+def test_execution_guard_allows_clean_live_context() -> None:
+    gate = ManualApprovalGate()
+    ticket = gate.approve(gate.request("live_execution", "test"), approved_by="operator")
+    guard = ExecutionGuard(gate)
+
+    decision = guard.can_execute(
+        mode="live",
+        safety_state=SafetyState(
+            safe_mode=False,
+            kill_switch=False,
+            stale_data_lock=False,
+            disconnect_lock=False,
+            reasons=(),
+        ),
+        approval_ticket=ticket,
+        secrets_ready=True,
+        market_data_fresh=True,
+        stale_data_age_seconds=2.0,
+        stale_data_max_age_seconds=15.0,
+        venue_session_connected=True,
+        cancel_on_disconnect_supported=True,
+        cancel_on_disconnect_required=True,
+        current_open_positions=1,
+        max_open_positions=3,
+        requested_notional_usdc=10.0,
+        max_position_notional_usdc=25.0,
+    )
+
+    assert decision.allowed is True
+    assert decision.vetoes == ()
+    assert decision.cancel_on_disconnect_required is True

--- a/tests/test_execution_storage.py
+++ b/tests/test_execution_storage.py
@@ -1,0 +1,35 @@
+from superajan12.storage import SQLiteStore
+
+
+def test_execution_storage_persists_session_and_latest_veto(tmp_path) -> None:
+    sqlite_path = tmp_path / "execution.sqlite3"
+    store = SQLiteStore(sqlite_path)
+
+    store.save_execution_session(
+        session_id="sess-1",
+        connected=False,
+        cancel_on_disconnect_supported=True,
+        cancel_on_disconnect_armed=True,
+        stale_data_locked=True,
+        disconnect_reason="socket dropped",
+        open_order_count=2,
+    )
+    store.record_execution_veto(
+        scope="live_execution",
+        vetoes=("stale-data lock blocks execution", "hard open-position cap reached"),
+    )
+
+    session = store.latest_execution_session()
+    veto = store.latest_execution_veto("live_execution")
+
+    assert session is not None
+    assert session["session_id"] == "sess-1"
+    assert session["connected"] is False
+    assert session["cancel_on_disconnect_armed"] is True
+    assert session["stale_data_locked"] is True
+    assert session["open_order_count"] == 2
+    assert veto is not None
+    assert veto["vetoes"] == [
+        "stale-data lock blocks execution",
+        "hard open-position cap reached",
+    ]

--- a/tests/test_live_connector.py
+++ b/tests/test_live_connector.py
@@ -1,0 +1,89 @@
+from datetime import datetime, timedelta, timezone
+
+from superajan12.approval import ManualApprovalGate
+from superajan12.execution_guard import ExecutionGuard
+from superajan12.live_connector import LiveExecutionConnector
+from superajan12.safety import SafetyState
+
+
+def _allowed_decision():
+    gate = ManualApprovalGate()
+    ticket = gate.approve(gate.request("live_execution", "test"), approved_by="operator")
+    return ExecutionGuard(gate).can_execute(
+        mode="live",
+        safety_state=SafetyState(
+            safe_mode=False,
+            kill_switch=False,
+            stale_data_lock=False,
+            disconnect_lock=False,
+            reasons=(),
+        ),
+        approval_ticket=ticket,
+        secrets_ready=True,
+    )
+
+
+def test_live_connector_arms_cancel_on_disconnect_and_prepares_order() -> None:
+    connector = LiveExecutionConnector()
+    session = connector.open_session(
+        session_id="sess-1",
+        cancel_on_disconnect_supported=True,
+        cancel_on_disconnect_required=True,
+    )
+
+    order = connector.prepare_order(
+        _allowed_decision(),
+        market_id="m1",
+        side="YES",
+        price=0.5,
+        size=2.0,
+        session=session,
+        stale_after_seconds=15.0,
+    )
+
+    assert order.cancel_on_disconnect is True
+    assert order.session_id == "sess-1"
+    assert order.stale_after_seconds == 15.0
+
+
+def test_live_connector_disconnect_triggers_cancel_or_kill_switch() -> None:
+    connector = LiveExecutionConnector()
+    armed_session = connector.open_session(
+        session_id="sess-armed",
+        cancel_on_disconnect_supported=True,
+        cancel_on_disconnect_required=True,
+    )
+    unarmed_session = connector.open_session(
+        session_id="sess-unarmed",
+        cancel_on_disconnect_supported=False,
+        cancel_on_disconnect_required=True,
+    )
+
+    armed = connector.handle_disconnect(armed_session, reason="socket dropped", open_order_count=2)
+    unarmed = connector.handle_disconnect(unarmed_session, reason="socket dropped", open_order_count=2)
+
+    assert armed.cancel_open_orders is True
+    assert armed.activate_kill_switch is False
+    assert armed.session.connected is False
+    assert armed.session.stale_data_locked is True
+    assert unarmed.cancel_open_orders is False
+    assert unarmed.activate_kill_switch is True
+
+
+def test_live_connector_locks_stale_data_after_heartbeat_gap() -> None:
+    connector = LiveExecutionConnector()
+    session = connector.open_session(
+        session_id="sess-stale",
+        cancel_on_disconnect_supported=True,
+        cancel_on_disconnect_required=True,
+    )
+    old = datetime.now(timezone.utc) - timedelta(seconds=20)
+    session = connector.mark_heartbeat(session, at=old)
+
+    locked = connector.lock_stale_data(
+        session,
+        now=datetime.now(timezone.utc),
+        stale_after_seconds=15.0,
+    )
+
+    assert locked.stale_data_locked is True

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -37,3 +37,23 @@ def test_clear_safe_mode_resets_kill_switch_state() -> None:
     assert state.kill_switch is False
     assert state.can_open_new_positions is True
     assert state.reasons == ()
+
+
+def test_safety_controller_tracks_stale_and_disconnect_locks() -> None:
+    controller = SafetyController()
+    controller.enable_stale_data_lock("stale feed")
+    controller.enable_disconnect_lock("venue disconnected")
+
+    state = controller.state()
+
+    assert state.stale_data_lock is True
+    assert state.disconnect_lock is True
+    assert state.can_open_new_positions is False
+    assert "stale feed" in state.reasons
+    assert "venue disconnected" in state.reasons
+
+    controller.clear_safe_mode()
+    cleared = controller.state()
+    assert cleared.stale_data_lock is False
+    assert cleared.disconnect_lock is False
+    assert cleared.can_open_new_positions is True


### PR DESCRIPTION
## What changed
- expand runtime settings with stale-data, disconnect, position-cap and cancel-on-disconnect thresholds
- harden `SafetyState` so stale-data and disconnect locks block new positions alongside safe mode and kill switch
- grow `ExecutionGuard` into a real veto engine with stale-data lock, disconnect checks, hard open-position caps, per-order notional caps and explicit pre-trade veto reasons
- model execution sessions inside `LiveExecutionConnector`, including heartbeat freshness, stale-data locking and disconnect resolution behavior
- persist execution sessions and veto events in SQLite for later audit and operator review
- update CLI dry-run helpers and add focused regression coverage for guard, connector, storage and safety behavior

## Why
- the previous execution layer only checked mode, approval and secrets, which was too thin for a live safety cage
- cancel-on-disconnect and stale-data locks need explicit modeled behavior so the system can fail closed when connectivity or data freshness degrades
- hard caps and veto persistence make the execution path easier to audit and much harder to accidentally overrun

## Validation
- added focused tests for execution guard vetoes, live connector disconnect/staleness behavior, execution session persistence, and safety lock handling
- I could not run the full suite in this container because the repository is not available locally and direct GitHub/network checkout paths are blocked here
