### PR TITLE
[codex] Add 50 engineering agent workflow

### DIFF
--- a/docs/engineering-agents/README.md
+++ b/docs/engineering-agents/README.md
@@ -1,0 +1,54 @@
+# 50 Engineering Agent Workflow
+
+This folder defines the 50-agent development support system for SuperAjan12.
+
+Important boundary: these agents are not runtime trading agents. They do not place orders, do not run inside `src/superajan12`, and do not change live execution behavior directly. They are engineering roles used to research, review, test, and prepare changes faster.
+
+Target improvement: move the system from roughly 35/100 readiness toward 50/100 by focusing on the largest missing engineering areas.
+
+## Operating rules
+
+1. Every agent must produce evidence: research notes, patch plan, tests, or review findings.
+2. No agent may enable live order submission.
+3. No agent may add secrets or credentials to the repository.
+4. Any code change must be covered by tests or a documented validation path.
+5. Runtime trading code and engineering workflow documentation must stay separate.
+6. Merge candidates must pass the merge rules in `merge-rules.md`.
+
+## Agent groups
+
+- Agents 01-10: real venue adapters
+- Agents 11-18: market data, orderbook, replay
+- Agents 19-26: risk, capital, kill switch
+- Agents 27-32: alpha research and backtest
+- Agents 33-37: observability, incident, chaos
+- Agents 38-42: dashboard and operator UX
+- Agents 43-46: security, secrets, compliance
+- Agents 47-50: packaging, release, CI
+
+## Deliverable format
+
+Each agent should report with this shape:
+
+```text
+Agent: AG-XX Name
+Scope:
+Files reviewed:
+Research sources:
+Findings:
+Patch proposal:
+Tests required:
+Risks:
+Ready for implementation: yes/no
+```
+
+## Readiness goal
+
+50/100 is not production-live. It means:
+
+- testnet/paper/shadow paths are more realistic,
+- adapter contracts are actionable,
+- replay and backtest can evaluate decisions,
+- safety gates are harder to bypass,
+- operators can see system state and incidents,
+- CI/release is stable enough for regular development.

--- a/docs/engineering-agents/agent-registry.md
+++ b/docs/engineering-agents/agent-registry.md
@@ -1,0 +1,221 @@
+# 50 Engineering Agent Registry
+
+This registry assigns the 50 development-support agents. These agents support engineering work only; they are not runtime trading agents.
+
+## Venue adapter agents
+
+### AG-01 Deribit REST Agent
+- Scope: Deribit public/testnet REST contract research and adapter patch plan.
+- Review: venue adapter code, endpoint docs, tests.
+- Output: mapping table, fake response fixtures, adapter test checklist.
+
+### AG-02 Deribit WebSocket Agent
+- Scope: Deribit streaming orderbook/trade subscriptions.
+- Review: reconnect, subscription, sequence behavior.
+- Output: WS lifecycle plan and failure cases.
+
+### AG-03 Binance Public REST Agent
+- Scope: Binance spot/futures exchange info, ticker, orderbook, mark/funding endpoints.
+- Output: normalized adapter mapping and rate-limit notes.
+
+### AG-04 Binance Diff-Depth Agent
+- Scope: snapshot + diff-depth merge logic.
+- Output: gap recovery design and deterministic fixture cases.
+
+### AG-05 Coinbase Preview Agent
+- Scope: Coinbase Advanced Trade preview-only order path.
+- Output: dry-run preview contract and response normalization.
+
+### AG-06 Coinbase Product/Portfolio Agent
+- Scope: product, account and portfolio boundary research.
+- Output: account separation constraints and test fixtures.
+
+### AG-07 OKX Policy Gate Agent
+- Scope: OKX API agreement, KYC/account gate and policy readiness.
+- Output: policy watcher input requirements.
+
+### AG-08 OKX Market Data Agent
+- Scope: ticker, book and candle mapping.
+- Output: adapter contract and rate-limit notes.
+
+### AG-09 Venue Capability Agent
+- Scope: shared venue capability schema.
+- Output: capability registry fields and readiness blockers.
+
+### AG-10 Venue Harness Agent
+- Scope: fake venue harness for all adapter tests.
+- Output: reusable fixture protocol.
+
+## Market data / orderbook / replay agents
+
+### AG-11 Snapshot Agent
+- Scope: canonical orderbook snapshot model.
+- Output: required fields and validation rules.
+
+### AG-12 Diff Merge Agent
+- Scope: deterministic merge of book diffs into snapshots.
+- Output: merge algorithm spec and tests.
+
+### AG-13 Gap Recovery Agent
+- Scope: sequence gap detection, quarantine, resnapshot.
+- Output: recovery state machine.
+
+### AG-14 Checksum Agent
+- Scope: venue-aware checksum validation.
+- Output: checksum policy by venue.
+
+### AG-15 Replay Event Agent
+- Scope: replay event schema.
+- Output: event envelope and persistence requirements.
+
+### AG-16 Replay Runner Agent
+- Scope: deterministic replay runner CLI/API.
+- Output: runner design and pass/fail criteria.
+
+### AG-17 Fixture Agent
+- Scope: reusable market data fixtures.
+- Output: fixture inventory and naming convention.
+
+### AG-18 Market-State QA Agent
+- Scope: regression tests for stale, synthetic, gap and checksum cases.
+- Output: expanded test matrix.
+
+## Risk / capital / kill-switch agents
+
+### AG-19 Position Cap Agent
+- Scope: hard position cap and notional cap enforcement.
+- Output: cap scenario table.
+
+### AG-20 Daily Loss Agent
+- Scope: daily loss buffer and shutdown behavior.
+- Output: drawdown gate policy.
+
+### AG-21 Stale Data Lock Agent
+- Scope: stale market data vetoes.
+- Output: stale lock rules and tests.
+
+### AG-22 Disconnect Lock Agent
+- Scope: disconnect/cancel behavior.
+- Output: cancel-on-disconnect policy and tests.
+
+### AG-23 Capital Ladder Agent
+- Scope: capital budgets by paper/shadow/testnet/canary/scaled stage.
+- Output: stage budget table.
+
+### AG-24 Kill Switch Agent
+- Scope: soft/hard kill switch state machine.
+- Output: release protocol and audit requirements.
+
+### AG-25 Pre-Trade Veto Agent
+- Scope: normalized veto reasons.
+- Output: veto taxonomy.
+
+### AG-26 Risk QA Agent
+- Scope: risk regression test suite.
+- Output: must-pass scenarios.
+
+## Alpha research / backtest agents
+
+### AG-27 Feature Registry Agent
+- Scope: candidate feature inventory and feature provenance.
+- Output: feature registry draft.
+
+### AG-28 Metrics Agent
+- Scope: backtest metrics and calibration.
+- Output: metrics contract.
+
+### AG-29 Slippage Agent
+- Scope: slippage/fill quality model.
+- Output: paper-shadow-live gap model.
+
+### AG-30 Walk-Forward Agent
+- Scope: anti-overfit validation splits.
+- Output: walk-forward policy.
+
+### AG-31 Promotion Gate Agent
+- Scope: model promotion policy.
+- Output: promotion criteria and blockers.
+
+### AG-32 Alpha Report Agent
+- Scope: decision quality report.
+- Output: report template.
+
+## Observability / incident / chaos agents
+
+### AG-33 Metrics Taxonomy Agent
+- Scope: production metrics.
+- Output: metric names, types, thresholds.
+
+### AG-34 Trace Agent
+- Scope: trace ids and event chain linking.
+- Output: trace propagation plan.
+
+### AG-35 Incident Agent
+- Scope: open/ack/resolve/postmortem lifecycle.
+- Output: incident model and tests.
+
+### AG-36 Chaos Agent
+- Scope: failure injection matrix.
+- Output: chaos scenarios.
+
+### AG-37 Alert Agent
+- Scope: alert thresholds and operator escalation.
+- Output: alert table.
+
+## Dashboard / operator UX agents
+
+### AG-38 Readiness UX Agent
+- Scope: stage/readiness blocker screen.
+- Output: operator UI spec.
+
+### AG-39 Risk UX Agent
+- Scope: caps, locks, vetoes view.
+- Output: risk panel spec.
+
+### AG-40 Venue UX Agent
+- Scope: venue capability/health panel.
+- Output: venue panel spec.
+
+### AG-41 Replay UX Agent
+- Scope: replay/backtest run screen.
+- Output: replay UX flow.
+
+### AG-42 Incident UX Agent
+- Scope: incident/postmortem screen.
+- Output: incident UX flow.
+
+## Security / secrets / compliance agents
+
+### AG-43 Secret Inventory Agent
+- Scope: required env-only secret list.
+- Output: secret inventory without values.
+
+### AG-44 Secret Rotation Agent
+- Scope: owner/provider/age checks.
+- Output: rotation policy.
+
+### AG-45 Compliance Boundary Agent
+- Scope: live trading constraints and non-goals.
+- Output: compliance guardrails.
+
+### AG-46 Audit Policy Agent
+- Scope: tamper-evident audit requirements.
+- Output: audit retention and integrity plan.
+
+## Packaging / release / CI agents
+
+### AG-47 CI Agent
+- Scope: unit/runtime/desktop/release lanes.
+- Output: CI improvement backlog.
+
+### AG-48 Release Artifact Agent
+- Scope: wheel/web/desktop bundle policy.
+- Output: artifact checklist.
+
+### AG-49 Local Smoke Agent
+- Scope: one-command local smoke test.
+- Output: smoke script requirements.
+
+### AG-50 Merge Manager Agent
+- Scope: final review and merge gate.
+- Output: PR checklist and rollback plan.

--- a/docs/engineering-agents/merge-rules.md
+++ b/docs/engineering-agents/merge-rules.md
@@ -1,0 +1,60 @@
+# Merge Rules for Engineering Agents
+
+These rules keep the 50-agent workflow from polluting the trading runtime.
+
+## Hard boundaries
+
+1. Engineering-agent docs must stay under `docs/engineering-agents/`.
+2. Engineering-agent orchestration must not be imported by `src/superajan12`.
+3. No PR may enable live order sending.
+4. No PR may commit API keys, secrets, tokens, `.env`, SQLite databases, JSONL audit logs, or local runtime data.
+5. Any connector or adapter that can touch accounts must default to dry-run/testnet-disabled mode until production checklist requirements are met.
+
+## Required evidence before merge
+
+Every implementation PR created from the agent workflow must include:
+
+- files changed
+- risk impact
+- test command and result
+- rollback plan
+- operator-visible change, if any
+- statement confirming live trading remains disabled
+
+## Test gates
+
+Minimum expected validation by change class:
+
+- Documentation only: markdown review and no runtime imports added.
+- Adapter contract: unit tests with fake venue responses.
+- Market data/orderbook: deterministic fixture tests for snapshot, diff, gap, and checksum behavior.
+- Risk/capital: scenario tests proving vetoes cannot be bypassed.
+- Replay/backtest: deterministic replay test with fixed input and expected output.
+- Dashboard: endpoint smoke test and browser/static asset sanity check.
+- Security/secrets: negative tests proving secret values are never logged.
+- CI/release: workflow syntax review and dry-run notes.
+
+## PR labels
+
+Recommended labels:
+
+- `area:venue`
+- `area:market-data`
+- `area:risk`
+- `area:alpha`
+- `area:observability`
+- `area:ux`
+- `area:security`
+- `area:release`
+- `safety:live-disabled`
+
+## Merge manager checklist
+
+AG-50 must confirm:
+
+1. Scope matches one or more agent tasks.
+2. Runtime impact is intentional and documented.
+3. Live execution remains disabled unless a future production checklist explicitly authorizes otherwise.
+4. Tests are appropriate for the touched area.
+5. Docs and runbooks are updated when operator behavior changes.
+6. The PR can be reverted cleanly.

--- a/docs/engineering-agents/research-queue.md
+++ b/docs/engineering-agents/research-queue.md
@@ -1,0 +1,42 @@
+# Research Queue
+
+This queue converts the 50 engineering agents into concrete research and implementation preparation work. Results should be added as notes or follow-up PRs; do not modify trading runtime behavior from this folder alone.
+
+## Wave A - must unblock 50/100 readiness
+
+1. Deribit public/testnet API contract: instruments, orderbook, trades, auth boundary, testnet caveats.
+2. Binance spot and futures public book contract: snapshot endpoint, diff stream semantics, sequence gap handling.
+3. Coinbase Advanced Trade preview contract: preview-only order path, product mapping, portfolio isolation.
+4. OKX market data and policy gate: account/KYC constraints, market data endpoints, rate-limit implications.
+5. Canonical orderbook event model: snapshot, diff, checksum, venue timestamp, local receipt timestamp.
+6. Replay event format: source, sequence, decision context, risk gate result, paper fill, shadow mark.
+7. Capital ladder: paper -> shadow -> testnet/demo -> canary -> scaled-live, with maximum risk per stage.
+8. Kill-switch release conditions: who/what can release, cooldown, audit trail, postmortem requirement.
+9. Backtest metrics: realized/unrealized PnL, max drawdown, hit rate, calibration, slippage impact.
+10. Operator cockpit gaps: readiness blockers, venue health, risk locks, incident state.
+
+## Wave B - implementation preparation
+
+1. Build fake venue harness for deterministic adapter tests.
+2. Build data fixtures for orderbook merge and replay.
+3. Build smoke script for local API and dashboard checks.
+4. Build incident lifecycle regression tests.
+5. Build secret inventory checker that never prints secret values.
+6. Build CI lane for unit + smoke + docs validation.
+
+## Research note template
+
+```text
+Topic:
+Agent:
+Sources checked:
+Current repo support:
+Gap:
+Recommended patch:
+Tests required:
+Safety concerns:
+```
+
+## Safety note
+
+Research must not result in live order execution being enabled. Any live adapter work must stay behind explicit dry-run/testnet gates until production checklist requirements are met.


### PR DESCRIPTION
## What changed
- Added a 50-agent engineering workflow under `docs/engineering-agents/`.
- Split agents across venue adapters, market data/replay, risk/capital, alpha/backtest, observability, operator UX, security/compliance, and CI/release.
- Added task board, research queue, registry, and merge rules.

## Safety boundary
- These are engineering support agents only.
- Nothing is imported by or injected into the trading runtime.
- No live order execution is enabled.
- No secrets or credentials are added.

## Goal
Use this workflow to move SuperAjan12 from roughly 35/100 readiness toward 50/100 through controlled research, patch planning, testing, and review.

## Validation
Documentation-only change. Runtime source code is untouched.