### PR TITLE
[codex] Add dry-run venue adapter contracts

### DIFF
--- a/docs/engineering-agents/venue-adapter-contract-implementation.md
+++ b/docs/engineering-agents/venue-adapter-contract-implementation.md
@@ -1,0 +1,37 @@
+# Venue Adapter Contract Implementation
+
+This is the first implementation PR generated from the 50 engineering-agent workflow.
+
+## Scope
+
+Agents covered:
+
+- AG-01 Deribit REST Agent
+- AG-03 Binance Public REST Agent
+- AG-05 Coinbase Preview Agent
+- AG-07 OKX Policy Gate Agent
+- AG-09 Venue Capability Agent
+- AG-10 Venue Harness Agent
+
+## What this adds
+
+- A normalized venue profile model.
+- Capability flags for orderbook, trades, candles, websocket, preview, testnet, account gates and policy gates.
+- A dry-run venue adapter harness.
+- Preview-only order validation that always keeps live submission disabled.
+- A registry for venue readiness summaries.
+- Tests proving the harness works with existing market-state validation.
+
+## Safety boundary
+
+This does not add account access, credentials, signing, or live order sending.
+
+The dry-run harness exists so future real adapters can be added behind tests without polluting the execution core or enabling live trading prematurely.
+
+## Next patches
+
+1. Add a deterministic orderbook fixture library.
+2. Add Binance snapshot + diff-depth merge fixtures.
+3. Add Deribit testnet/public data mapping notes.
+4. Add Coinbase preview response normalization fixtures.
+5. Add OKX policy watcher integration notes.

--- a/src/superajan12/venue_adapters.py
+++ b/src/superajan12/venue_adapters.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Protocol
+
+from superajan12.models import OrderBookLevel, OrderBookSnapshot
+
+
+class VenueName(str, Enum):
+    DERIBIT = "deribit"
+    BINANCE = "binance"
+    COINBASE = "coinbase"
+    OKX = "okx"
+
+
+class VenueCapability(str, Enum):
+    PUBLIC_ORDERBOOK = "public_orderbook"
+    PUBLIC_TRADES = "public_trades"
+    PUBLIC_CANDLES = "public_candles"
+    WEBSOCKET_ORDERBOOK = "websocket_orderbook"
+    ORDER_PREVIEW = "order_preview"
+    TESTNET = "testnet"
+    ACCOUNT_REQUIRED = "account_required"
+    POLICY_GATE_REQUIRED = "policy_gate_required"
+
+
+@dataclass(frozen=True)
+class VenueProfile:
+    name: VenueName
+    display_name: str
+    capabilities: tuple[VenueCapability, ...]
+    live_orders_enabled: bool = False
+    default_testnet: bool = True
+    notes: tuple[str, ...] = ()
+
+    def supports(self, capability: VenueCapability) -> bool:
+        return capability in self.capabilities
+
+
+@dataclass(frozen=True)
+class VenueOrderRequest:
+    venue: VenueName
+    symbol: str
+    side: str
+    price: float
+    size: float
+    client_order_id: str
+    dry_run: bool = True
+
+
+@dataclass(frozen=True)
+class VenueOrderPreview:
+    venue: VenueName
+    accepted: bool
+    dry_run: bool
+    reasons: tuple[str, ...]
+    normalized_symbol: str
+    estimated_notional_usdc: float
+
+
+@dataclass(frozen=True)
+class VenueHealth:
+    venue: VenueName
+    ok: bool
+    status: str
+    reasons: tuple[str, ...] = ()
+
+
+class VenueAdapter(Protocol):
+    profile: VenueProfile
+
+    def health(self) -> VenueHealth:
+        ...
+
+    def get_order_book(self, *, market_id: str, symbol: str, depth: int = 10) -> OrderBookSnapshot:
+        ...
+
+    def preview_order(self, request: VenueOrderRequest) -> VenueOrderPreview:
+        ...
+
+
+class DryRunVenueAdapter:
+    """Deterministic adapter harness used for contracts and tests.
+
+    This adapter never sends live orders. It gives the rest of the system a stable
+    contract for venue capabilities, orderbook snapshots and preview-only orders
+    before any real venue client is wired in.
+    """
+
+    def __init__(
+        self,
+        profile: VenueProfile,
+        *,
+        bid: float = 0.49,
+        ask: float = 0.51,
+        bid_size: float = 500.0,
+        ask_size: float = 500.0,
+        sequence: int = 1,
+    ) -> None:
+        self.profile = profile
+        self.bid = bid
+        self.ask = ask
+        self.bid_size = bid_size
+        self.ask_size = ask_size
+        self.sequence = sequence
+
+    def health(self) -> VenueHealth:
+        reasons: list[str] = ["dry-run harness"]
+        if not self.profile.live_orders_enabled:
+            reasons.append("live orders disabled")
+        return VenueHealth(
+            venue=self.profile.name,
+            ok=True,
+            status="ready",
+            reasons=tuple(reasons),
+        )
+
+    def get_order_book(self, *, market_id: str, symbol: str, depth: int = 10) -> OrderBookSnapshot:
+        if depth <= 0:
+            raise ValueError("depth must be positive")
+        bid_levels = [
+            OrderBookLevel(price=round(max(self.bid - i * 0.01, 0.01), 4), size=self.bid_size)
+            for i in range(depth)
+        ]
+        ask_levels = [
+            OrderBookLevel(price=round(min(self.ask + i * 0.01, 0.99), 4), size=self.ask_size)
+            for i in range(depth)
+        ]
+        return OrderBookSnapshot(
+            market_id=market_id,
+            yes_bids=bid_levels,
+            yes_asks=ask_levels,
+            source="venue_harness",
+            venue=self.profile.name.value,
+            token_id=symbol,
+            snapshot_kind="snapshot",
+            snapshot_id=f"{self.profile.name.value}:{symbol}:{self.sequence}",
+            sequence_start=self.sequence,
+            sequence_end=self.sequence,
+            checksum=f"dryrun-{self.profile.name.value}-{self.sequence}",
+            checksum_valid=True,
+            depth_levels=depth,
+        )
+
+    def preview_order(self, request: VenueOrderRequest) -> VenueOrderPreview:
+        reasons: list[str] = []
+        if request.venue != self.profile.name:
+            reasons.append("request venue does not match adapter")
+        if not request.dry_run:
+            reasons.append("live order submission is disabled")
+        if not self.profile.supports(VenueCapability.ORDER_PREVIEW):
+            reasons.append("venue does not support local order preview")
+        if request.price <= 0 or request.price >= 1:
+            reasons.append("price must be inside prediction-market bounds")
+        if request.size <= 0:
+            reasons.append("size must be positive")
+        if request.side.upper() not in {"YES", "NO", "BUY", "SELL"}:
+            reasons.append("unsupported side")
+
+        return VenueOrderPreview(
+            venue=self.profile.name,
+            accepted=not reasons,
+            dry_run=True,
+            reasons=tuple(reasons) if reasons else ("preview accepted",),
+            normalized_symbol=request.symbol.upper(),
+            estimated_notional_usdc=round(max(request.price, 0.0) * max(request.size, 0.0), 6),
+        )
+
+
+@dataclass
+class VenueAdapterRegistry:
+    adapters: dict[VenueName, VenueAdapter] = field(default_factory=dict)
+
+    def register(self, adapter: VenueAdapter) -> None:
+        self.adapters[adapter.profile.name] = adapter
+
+    def get(self, venue: VenueName) -> VenueAdapter:
+        if venue not in self.adapters:
+            raise KeyError(f"venue adapter not registered: {venue.value}")
+        return self.adapters[venue]
+
+    def profiles(self) -> tuple[VenueProfile, ...]:
+        return tuple(adapter.profile for adapter in self.adapters.values())
+
+    def readiness_summary(self) -> dict[str, dict[str, object]]:
+        summary: dict[str, dict[str, object]] = {}
+        for venue, adapter in self.adapters.items():
+            health = adapter.health()
+            summary[venue.value] = {
+                "display_name": adapter.profile.display_name,
+                "ok": health.ok,
+                "status": health.status,
+                "capabilities": [capability.value for capability in adapter.profile.capabilities],
+                "live_orders_enabled": adapter.profile.live_orders_enabled,
+                "default_testnet": adapter.profile.default_testnet,
+                "reasons": list(health.reasons),
+            }
+        return summary
+
+
+def default_venue_profiles() -> tuple[VenueProfile, ...]:
+    return (
+        VenueProfile(
+            name=VenueName.DERIBIT,
+            display_name="Deribit",
+            capabilities=(
+                VenueCapability.PUBLIC_ORDERBOOK,
+                VenueCapability.PUBLIC_TRADES,
+                VenueCapability.PUBLIC_CANDLES,
+                VenueCapability.WEBSOCKET_ORDERBOOK,
+                VenueCapability.TESTNET,
+            ),
+            notes=("testnet can be unavailable during maintenance",),
+        ),
+        VenueProfile(
+            name=VenueName.BINANCE,
+            display_name="Binance",
+            capabilities=(
+                VenueCapability.PUBLIC_ORDERBOOK,
+                VenueCapability.PUBLIC_TRADES,
+                VenueCapability.PUBLIC_CANDLES,
+                VenueCapability.WEBSOCKET_ORDERBOOK,
+                VenueCapability.TESTNET,
+            ),
+            notes=("diff-depth requires sequence and resnapshot recovery",),
+        ),
+        VenueProfile(
+            name=VenueName.COINBASE,
+            display_name="Coinbase Advanced Trade",
+            capabilities=(
+                VenueCapability.PUBLIC_ORDERBOOK,
+                VenueCapability.PUBLIC_TRADES,
+                VenueCapability.PUBLIC_CANDLES,
+                VenueCapability.ORDER_PREVIEW,
+                VenueCapability.ACCOUNT_REQUIRED,
+            ),
+            notes=("preview-only order flow must remain dry-run until live checklist passes",),
+        ),
+        VenueProfile(
+            name=VenueName.OKX,
+            display_name="OKX",
+            capabilities=(
+                VenueCapability.PUBLIC_ORDERBOOK,
+                VenueCapability.PUBLIC_TRADES,
+                VenueCapability.PUBLIC_CANDLES,
+                VenueCapability.WEBSOCKET_ORDERBOOK,
+                VenueCapability.POLICY_GATE_REQUIRED,
+                VenueCapability.ACCOUNT_REQUIRED,
+            ),
+            notes=("policy and account readiness gates must be checked before live work",),
+        ),
+    )
+
+
+def build_dry_run_venue_registry() -> VenueAdapterRegistry:
+    registry = VenueAdapterRegistry()
+    for profile in default_venue_profiles():
+        registry.register(DryRunVenueAdapter(profile))
+    return registry

--- a/tests/test_venue_adapters.py
+++ b/tests/test_venue_adapters.py
@@ -1,0 +1,99 @@
+from superajan12.market_state import MarketStateValidator
+from superajan12.models import Market
+from superajan12.venue_adapters import (
+    VenueCapability,
+    VenueName,
+    VenueOrderRequest,
+    build_dry_run_venue_registry,
+    default_venue_profiles,
+)
+
+
+def test_default_profiles_keep_live_orders_disabled() -> None:
+    profiles = default_venue_profiles()
+
+    assert {profile.name for profile in profiles} == {
+        VenueName.DERIBIT,
+        VenueName.BINANCE,
+        VenueName.COINBASE,
+        VenueName.OKX,
+    }
+    assert all(profile.live_orders_enabled is False for profile in profiles)
+
+
+def test_dry_run_registry_exposes_capability_summary() -> None:
+    registry = build_dry_run_venue_registry()
+
+    summary = registry.readiness_summary()
+
+    assert summary["deribit"]["ok"] is True
+    assert summary["binance"]["status"] == "ready"
+    assert "order_preview" in summary["coinbase"]["capabilities"]
+    assert "policy_gate_required" in summary["okx"]["capabilities"]
+    assert all(item["live_orders_enabled"] is False for item in summary.values())
+
+
+def test_dry_run_orderbook_is_market_state_compatible() -> None:
+    registry = build_dry_run_venue_registry()
+    adapter = registry.get(VenueName.BINANCE)
+    market = Market(id="btc-election", question="BTC above target?", volume_usdc=10_000, liquidity_usdc=5_000)
+
+    snapshot = adapter.get_order_book(market_id=market.id, symbol="BTCUSDT", depth=5)
+    result = MarketStateValidator().validate(market, snapshot)
+
+    assert snapshot.venue == "binance"
+    assert snapshot.depth_levels == 5
+    assert result.ok is True
+    assert result.status == "healthy"
+    assert result.sequence_status == "validated"
+    assert result.checksum_status == "validated"
+
+
+def test_preview_order_accepts_only_dry_run_supported_preview() -> None:
+    registry = build_dry_run_venue_registry()
+    adapter = registry.get(VenueName.COINBASE)
+
+    preview = adapter.preview_order(
+        VenueOrderRequest(
+            venue=VenueName.COINBASE,
+            symbol="btc-usd",
+            side="BUY",
+            price=0.55,
+            size=20,
+            client_order_id="preview-1",
+            dry_run=True,
+        )
+    )
+
+    assert preview.accepted is True
+    assert preview.dry_run is True
+    assert preview.normalized_symbol == "BTC-USD"
+    assert preview.estimated_notional_usdc == 11.0
+
+
+def test_preview_order_rejects_live_or_unsupported_requests() -> None:
+    registry = build_dry_run_venue_registry()
+    binance = registry.get(VenueName.BINANCE)
+
+    preview = binance.preview_order(
+        VenueOrderRequest(
+            venue=VenueName.BINANCE,
+            symbol="BTCUSDT",
+            side="BUY",
+            price=0.5,
+            size=10,
+            client_order_id="live-1",
+            dry_run=False,
+        )
+    )
+
+    assert preview.accepted is False
+    assert "live order submission is disabled" in preview.reasons
+    assert "venue does not support local order preview" in preview.reasons
+
+
+def test_profile_supports_capability_helper() -> None:
+    coinbase = next(profile for profile in default_venue_profiles() if profile.name == VenueName.COINBASE)
+
+    assert coinbase.supports(VenueCapability.ORDER_PREVIEW) is True
+    assert coinbase.supports(VenueCapability.WEBSOCKET_ORDERBOOK) is False


### PR DESCRIPTION
## What changed
- Added `src/superajan12/venue_adapters.py` with normalized venue profiles, capabilities, a dry-run adapter harness, preview-only order validation, and a registry summary.
- Added tests for live-disabled profiles, capability summaries, market-state-compatible orderbooks, and preview-only validation.
- Documented this as the first implementation patch from the 50 engineering-agent workflow.

## Safety boundary
- No live order sending is enabled.
- No secrets, credentials, signing, or account access are added.
- The adapter harness is deterministic and dry-run only.

## Validation
- Added `tests/test_venue_adapters.py`.
- Expected command: `pytest -q tests/test_venue_adapters.py tests/test_market_state.py`.

## Roadmap link
Starts the first 35/100 -> 50/100 milestone from #25 by giving real venue work a safe contract and test harness.