### PR TITLE
[codex] Add deterministic orderbook replay layer

### DIFF
--- a/docs/engineering-agents/market-data-replay-implementation.md
+++ b/docs/engineering-agents/market-data-replay-implementation.md
@@ -1,0 +1,45 @@
+# Market Data / Orderbook / Replay Implementation
+
+This patch strengthens the market data layer without enabling live trading.
+
+## Scope
+
+Agents covered:
+
+- AG-11 Snapshot Agent
+- AG-12 Diff Merge Agent
+- AG-13 Gap Recovery Agent
+- AG-14 Checksum Agent
+- AG-15 Replay Event Agent
+- AG-16 Replay Runner Agent
+- AG-17 Fixture Agent
+- AG-18 Market-State QA Agent
+
+## What this adds
+
+- Canonical replay event types: snapshot, diff and resnapshot.
+- Deterministic orderbook merge logic for bid/ask level updates.
+- Sequence gap rejection before bad diffs can mutate the local book.
+- Resnapshot recovery after a rejected gap.
+- Checksum validation integration through the existing `MarketStateValidator`.
+- Reusable Binance-style replay fixtures.
+- Regression tests for healthy replay, gap recovery, checksum mismatch, empty replay and custom validator thresholds.
+
+## Safety boundary
+
+This is market data and replay infrastructure only. It does not add API keys, account access, signing, live order submission or venue trading calls.
+
+## Validation
+
+Expected command:
+
+```bash
+pytest -q tests/test_orderbook_replay.py tests/test_market_state.py
+```
+
+## Next patches
+
+1. Add a local smoke script that runs replay plus existing scanner tests.
+2. Add replay report export to JSON for operator review.
+3. Add venue-specific checksum implementations once each real venue adapter lands.
+4. Add replay-driven risk/capital scenario tests.

--- a/src/superajan12/orderbook_replay.py
+++ b/src/superajan12/orderbook_replay.py
@@ -83,6 +83,7 @@ class DeterministicOrderBook:
         if event.event_type in {ReplayEventType.SNAPSHOT, ReplayEventType.RESNAPSHOT}:
             self.bids = self._levels_to_map(event.bids)
             self.asks = self._levels_to_map(event.asks)
+            previous = None
         elif event.event_type == ReplayEventType.DIFF:
             self._apply_deltas(self.bids, event.bids)
             self._apply_deltas(self.asks, event.asks)

--- a/src/superajan12/orderbook_replay.py
+++ b/src/superajan12/orderbook_replay.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+
+from superajan12.market_state import MarketStateValidation, MarketStateValidator
+from superajan12.models import Market, OrderBookLevel, OrderBookSnapshot
+
+
+class ReplayEventType(str, Enum):
+    SNAPSHOT = "snapshot"
+    DIFF = "diff"
+    RESNAPSHOT = "resnapshot"
+
+
+@dataclass(frozen=True)
+class OrderBookDelta:
+    side: str
+    price: float
+    size: float
+
+
+@dataclass(frozen=True)
+class ReplayEvent:
+    event_type: ReplayEventType
+    market_id: str
+    venue: str
+    symbol: str
+    sequence_start: int
+    sequence_end: int
+    bids: tuple[OrderBookDelta, ...] = ()
+    asks: tuple[OrderBookDelta, ...] = ()
+    checksum: str | None = None
+    checksum_valid: bool | None = True
+    captured_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    received_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+@dataclass(frozen=True)
+class ReplayStep:
+    event: ReplayEvent
+    snapshot: OrderBookSnapshot | None
+    validation: MarketStateValidation
+    action: str
+
+
+@dataclass(frozen=True)
+class ReplayReport:
+    market_id: str
+    venue: str
+    total_events: int
+    accepted_events: int
+    rejected_events: int
+    resnapshot_events: int
+    final_snapshot: OrderBookSnapshot | None
+    steps: tuple[ReplayStep, ...]
+
+    @property
+    def ok(self) -> bool:
+        return self.rejected_events == 0 and self.final_snapshot is not None
+
+
+class DeterministicOrderBook:
+    def __init__(self, *, market_id: str, venue: str, symbol: str) -> None:
+        self.market_id = market_id
+        self.venue = venue
+        self.symbol = symbol
+        self.bids: dict[float, float] = {}
+        self.asks: dict[float, float] = {}
+        self.sequence_end: int | None = None
+        self.snapshot_id: str | None = None
+
+    def apply(self, event: ReplayEvent) -> OrderBookSnapshot:
+        if event.market_id != self.market_id:
+            raise ValueError("event market id does not match book")
+        if event.venue != self.venue:
+            raise ValueError("event venue does not match book")
+        if event.symbol != self.symbol:
+            raise ValueError("event symbol does not match book")
+
+        previous = self.sequence_end
+        if event.event_type in {ReplayEventType.SNAPSHOT, ReplayEventType.RESNAPSHOT}:
+            self.bids = self._levels_to_map(event.bids)
+            self.asks = self._levels_to_map(event.asks)
+        elif event.event_type == ReplayEventType.DIFF:
+            self._apply_deltas(self.bids, event.bids)
+            self._apply_deltas(self.asks, event.asks)
+        else:
+            raise ValueError(f"unsupported replay event type: {event.event_type}")
+
+        self.sequence_end = event.sequence_end
+        self.snapshot_id = f"{event.venue}:{event.symbol}:{event.sequence_end}"
+        return self.to_snapshot(event=event, previous_sequence_end=previous)
+
+    def to_snapshot(self, *, event: ReplayEvent, previous_sequence_end: int | None) -> OrderBookSnapshot:
+        bids = [
+            OrderBookLevel(price=price, size=size)
+            for price, size in sorted(self.bids.items(), key=lambda item: item[0], reverse=True)
+        ]
+        asks = [
+            OrderBookLevel(price=price, size=size)
+            for price, size in sorted(self.asks.items(), key=lambda item: item[0])
+        ]
+        return OrderBookSnapshot(
+            market_id=self.market_id,
+            yes_bids=bids,
+            yes_asks=asks,
+            source="deterministic_replay",
+            venue=self.venue,
+            token_id=self.symbol,
+            snapshot_kind=event.event_type.value,
+            snapshot_id=self.snapshot_id,
+            sequence_start=event.sequence_start,
+            sequence_end=event.sequence_end,
+            previous_sequence_end=previous_sequence_end,
+            checksum=event.checksum,
+            checksum_valid=event.checksum_valid,
+            depth_levels=min(len(bids), len(asks)),
+            captured_at=event.captured_at,
+            received_at=event.received_at,
+        )
+
+    def _levels_to_map(self, deltas: tuple[OrderBookDelta, ...]) -> dict[float, float]:
+        levels: dict[float, float] = {}
+        for delta in deltas:
+            if delta.size > 0:
+                levels[round(delta.price, 8)] = delta.size
+        return levels
+
+    def _apply_deltas(self, levels: dict[float, float], deltas: tuple[OrderBookDelta, ...]) -> None:
+        for delta in deltas:
+            price = round(delta.price, 8)
+            if delta.size <= 0:
+                levels.pop(price, None)
+            else:
+                levels[price] = delta.size
+
+
+class DeterministicReplayRunner:
+    def __init__(self, *, validator: MarketStateValidator | None = None) -> None:
+        self.validator = validator or MarketStateValidator()
+
+    def run(self, *, market: Market, events: list[ReplayEvent]) -> ReplayReport:
+        if not events:
+            invalid = self.validator.validate(market, None)
+            return ReplayReport(
+                market_id=market.id,
+                venue="unknown",
+                total_events=0,
+                accepted_events=0,
+                rejected_events=1,
+                resnapshot_events=0,
+                final_snapshot=None,
+                steps=(ReplayStep(event=self._empty_event(market.id), snapshot=None, validation=invalid, action="reject"),),
+            )
+
+        first = events[0]
+        book = DeterministicOrderBook(market_id=first.market_id, venue=first.venue, symbol=first.symbol)
+        steps: list[ReplayStep] = []
+        accepted = 0
+        rejected = 0
+        resnapshots = 0
+        final_snapshot: OrderBookSnapshot | None = None
+
+        for event in events:
+            if event.event_type == ReplayEventType.DIFF and book.sequence_end is not None:
+                expected_next = book.sequence_end + 1
+                if event.sequence_start > expected_next:
+                    snapshot = book.to_snapshot(event=event, previous_sequence_end=book.sequence_end)
+                    validation = self.validator.validate(market, snapshot)
+                    steps.append(ReplayStep(event=event, snapshot=snapshot, validation=validation, action="reject_gap"))
+                    rejected += 1
+                    continue
+
+            snapshot = book.apply(event)
+            validation = self.validator.validate(market, snapshot)
+            action = "accept" if validation.ok else "reject"
+            if event.event_type == ReplayEventType.RESNAPSHOT:
+                resnapshots += 1
+                action = "resnapshot" if validation.ok else "reject_resnapshot"
+
+            steps.append(ReplayStep(event=event, snapshot=snapshot, validation=validation, action=action))
+            if validation.ok:
+                accepted += 1
+                final_snapshot = snapshot
+            else:
+                rejected += 1
+
+        return ReplayReport(
+            market_id=market.id,
+            venue=first.venue,
+            total_events=len(events),
+            accepted_events=accepted,
+            rejected_events=rejected,
+            resnapshot_events=resnapshots,
+            final_snapshot=final_snapshot,
+            steps=tuple(steps),
+        )
+
+    def _empty_event(self, market_id: str) -> ReplayEvent:
+        return ReplayEvent(
+            event_type=ReplayEventType.SNAPSHOT,
+            market_id=market_id,
+            venue="unknown",
+            symbol="unknown",
+            sequence_start=0,
+            sequence_end=0,
+        )
+
+
+def fixture_healthy_binance_replay(*, market_id: str = "m-binance", symbol: str = "BTCUSDT") -> list[ReplayEvent]:
+    now = datetime.now(timezone.utc)
+    return [
+        ReplayEvent(
+            event_type=ReplayEventType.SNAPSHOT,
+            market_id=market_id,
+            venue="binance",
+            symbol=symbol,
+            sequence_start=100,
+            sequence_end=100,
+            bids=(OrderBookDelta("bid", 0.49, 500), OrderBookDelta("bid", 0.48, 400)),
+            asks=(OrderBookDelta("ask", 0.51, 500), OrderBookDelta("ask", 0.52, 400)),
+            checksum="binance-100",
+            checksum_valid=True,
+            captured_at=now,
+            received_at=now,
+        ),
+        ReplayEvent(
+            event_type=ReplayEventType.DIFF,
+            market_id=market_id,
+            venue="binance",
+            symbol=symbol,
+            sequence_start=101,
+            sequence_end=101,
+            bids=(OrderBookDelta("bid", 0.50, 250),),
+            asks=(OrderBookDelta("ask", 0.51, 0), OrderBookDelta("ask", 0.515, 300)),
+            checksum="binance-101",
+            checksum_valid=True,
+            captured_at=now,
+            received_at=now,
+        ),
+        ReplayEvent(
+            event_type=ReplayEventType.DIFF,
+            market_id=market_id,
+            venue="binance",
+            symbol=symbol,
+            sequence_start=102,
+            sequence_end=102,
+            bids=(OrderBookDelta("bid", 0.475, 350),),
+            asks=(OrderBookDelta("ask", 0.525, 350),),
+            checksum="binance-102",
+            checksum_valid=True,
+            captured_at=now,
+            received_at=now,
+        ),
+    ]
+
+
+def fixture_gap_then_resnapshot(*, market_id: str = "m-gap", symbol: str = "BTCUSDT") -> list[ReplayEvent]:
+    now = datetime.now(timezone.utc)
+    return [
+        ReplayEvent(
+            event_type=ReplayEventType.SNAPSHOT,
+            market_id=market_id,
+            venue="binance",
+            symbol=symbol,
+            sequence_start=10,
+            sequence_end=10,
+            bids=(OrderBookDelta("bid", 0.49, 500),),
+            asks=(OrderBookDelta("ask", 0.51, 500),),
+            checksum="gap-10",
+            checksum_valid=True,
+            captured_at=now,
+            received_at=now,
+        ),
+        ReplayEvent(
+            event_type=ReplayEventType.DIFF,
+            market_id=market_id,
+            venue="binance",
+            symbol=symbol,
+            sequence_start=13,
+            sequence_end=13,
+            bids=(OrderBookDelta("bid", 0.50, 250),),
+            asks=(OrderBookDelta("ask", 0.52, 250),),
+            checksum="gap-13",
+            checksum_valid=True,
+            captured_at=now,
+            received_at=now,
+        ),
+        ReplayEvent(
+            event_type=ReplayEventType.RESNAPSHOT,
+            market_id=market_id,
+            venue="binance",
+            symbol=symbol,
+            sequence_start=14,
+            sequence_end=14,
+            bids=(OrderBookDelta("bid", 0.48, 600),),
+            asks=(OrderBookDelta("ask", 0.52, 600),),
+            checksum="gap-14",
+            checksum_valid=True,
+            captured_at=now,
+            received_at=now,
+        ),
+    ]

--- a/tests/test_orderbook_replay.py
+++ b/tests/test_orderbook_replay.py
@@ -1,0 +1,90 @@
+from superajan12.market_state import MarketStateValidator
+from superajan12.models import Market
+from superajan12.orderbook_replay import (
+    DeterministicReplayRunner,
+    ReplayEvent,
+    ReplayEventType,
+    fixture_gap_then_resnapshot,
+    fixture_healthy_binance_replay,
+)
+
+
+def test_healthy_binance_replay_accepts_all_events() -> None:
+    market = Market(id="m-binance", question="BTC above target?", volume_usdc=10_000, liquidity_usdc=5_000)
+    runner = DeterministicReplayRunner()
+
+    report = runner.run(market=market, events=fixture_healthy_binance_replay())
+
+    assert report.ok is True
+    assert report.total_events == 3
+    assert report.accepted_events == 3
+    assert report.rejected_events == 0
+    assert report.final_snapshot is not None
+    assert report.final_snapshot.best_bid == 0.5
+    assert report.final_snapshot.best_ask == 0.515
+    assert report.final_snapshot.sequence_end == 102
+
+
+def test_replay_rejects_gap_and_recovers_on_resnapshot() -> None:
+    market = Market(id="m-gap", question="Gap recovery?", volume_usdc=10_000, liquidity_usdc=5_000)
+    runner = DeterministicReplayRunner()
+
+    report = runner.run(market=market, events=fixture_gap_then_resnapshot())
+
+    assert report.ok is False
+    assert report.total_events == 3
+    assert report.accepted_events == 2
+    assert report.rejected_events == 1
+    assert report.resnapshot_events == 1
+    assert [step.action for step in report.steps] == ["accept", "reject_gap", "resnapshot"]
+    assert report.final_snapshot is not None
+    assert report.final_snapshot.sequence_end == 14
+    assert report.final_snapshot.best_bid == 0.48
+
+
+def test_replay_rejects_checksum_mismatch() -> None:
+    market = Market(id="m-binance", question="Checksum?", volume_usdc=10_000, liquidity_usdc=5_000)
+    events = fixture_healthy_binance_replay()
+    bad_event = ReplayEvent(
+        event_type=ReplayEventType.DIFF,
+        market_id="m-binance",
+        venue="binance",
+        symbol="BTCUSDT",
+        sequence_start=103,
+        sequence_end=103,
+        bids=(),
+        asks=(),
+        checksum="bad-103",
+        checksum_valid=False,
+    )
+    runner = DeterministicReplayRunner()
+
+    report = runner.run(market=market, events=[*events, bad_event])
+
+    assert report.ok is False
+    assert report.rejected_events == 1
+    assert report.steps[-1].validation.checksum_status == "invalid"
+    assert "order book checksum mismatch" in report.steps[-1].validation.reasons
+
+
+def test_empty_replay_is_invalid() -> None:
+    market = Market(id="empty", question="No events?")
+    runner = DeterministicReplayRunner()
+
+    report = runner.run(market=market, events=[])
+
+    assert report.ok is False
+    assert report.total_events == 0
+    assert report.rejected_events == 1
+    assert report.final_snapshot is None
+
+
+def test_replay_uses_custom_validator_thresholds() -> None:
+    market = Market(id="m-binance", question="Depth?", volume_usdc=10_000, liquidity_usdc=5_000)
+    runner = DeterministicReplayRunner(validator=MarketStateValidator(min_depth_usdc=10_000))
+
+    report = runner.run(market=market, events=fixture_healthy_binance_replay())
+
+    assert report.ok is True
+    assert all(step.validation.status == "degraded" for step in report.steps)
+    assert any("depth" in reason for reason in report.steps[0].validation.reasons)


### PR DESCRIPTION
## What changed
- Added `src/superajan12/orderbook_replay.py` with canonical replay events, deterministic book merge, gap rejection, resnapshot recovery, and replay reports.
- Added reusable Binance-style replay fixtures.
- Added regression tests for healthy replay, gap recovery, checksum mismatch, empty replay, and custom validator thresholds.
- Documented the market data/replay implementation under engineering-agent docs.

## Safety boundary
- Market data/replay only.
- No live order sending.
- No secrets, credentials, signing, account access, or trading calls.

## Validation
- Added `tests/test_orderbook_replay.py`.
- Expected command: `pytest -q tests/test_orderbook_replay.py tests/test_market_state.py`.

## Roadmap link
Advances #25 by strengthening the market data / orderbook / replay layer needed for 35/100 -> 50/100 readiness.