### PR TITLE
[codex] Harden risk capital and kill-switch vetoes

### DIFF
--- a/docs/engineering-agents/agent-200-execution-board.md
+++ b/docs/engineering-agents/agent-200-execution-board.md
@@ -1,0 +1,52 @@
+# 200 Engineering Agent Execution Board
+
+This board expands the existing 50-agent workflow into 200 implementation tasks. These are engineering-support agents, not runtime trading bots. They do not run inside the trading system and they do not enable live orders.
+
+## Operating boundary
+
+- Engineering agents produce research, patch plans, tests and review evidence.
+- Runtime code changes only happen through normal PRs.
+- Live order submission remains disabled until production checklist and manual approval gates are complete.
+- No secrets, credentials, account keys or local runtime databases may be committed.
+
+## Wave 1: 35/100 -> 50/100
+
+1. Venue adapter contracts and fake harness.
+2. Market data / orderbook / deterministic replay.
+3. Risk / capital / kill-switch hardening.
+4. Operator readiness surface.
+5. Local smoke and CI enforcement.
+
+## Agent allocation
+
+| Range | Area | Objective |
+|---|---|---|
+| AG-001..AG-025 | Venue adapters | Deribit, Binance, Coinbase, OKX contracts, fixtures, public/testnet boundaries |
+| AG-026..AG-050 | Market data | Snapshot/diff/checksum/gap/replay fixture coverage |
+| AG-051..AG-075 | Risk and capital | Hard caps, daily loss, exposure, stale data, veto taxonomy |
+| AG-076..AG-095 | Kill switch and safety | Soft/hard kill, release gates, disconnect and safe-mode behavior |
+| AG-096..AG-120 | Alpha/backtest | Feature registry, replay metrics, slippage, walk-forward validation |
+| AG-121..AG-140 | Observability | Metrics, traces, incident lifecycle, alert taxonomy, chaos tests |
+| AG-141..AG-160 | Operator UX | Readiness, risk, venue, replay, incident screens |
+| AG-161..AG-175 | Security/secrets | Secret inventory, rotation, no-leak tests, audit retention |
+| AG-176..AG-190 | Release/CI | Unit, runtime-compat, desktop, smoke, release artifact gates |
+| AG-191..AG-200 | Merge and QA | Final review, rollback plans, documentation, readiness scoring |
+
+## Current collected batch
+
+This branch collects work from AG-051..AG-095 first:
+
+- hard position/exposure caps
+- daily loss guard
+- stale-data lock
+- disconnect lock
+- kill-switch veto
+- pre-trade veto reason taxonomy
+- scenario tests for the risk engine
+
+## Definition of done for this batch
+
+- Existing risk behavior remains backward compatible.
+- New scenario tests prove vetoes cannot be bypassed.
+- Live order submission remains disabled.
+- Risk decisions expose explicit, operator-readable reasons.

--- a/docs/engineering-agents/risk-capital-kill-implementation.md
+++ b/docs/engineering-agents/risk-capital-kill-implementation.md
@@ -1,0 +1,40 @@
+# Risk / Capital / Kill-Switch Hardening
+
+This patch collects work from the expanded 200-agent execution board, focused on AG-051..AG-095.
+
+## Scope
+
+- hard market exposure caps
+- total exposure caps
+- daily loss guard
+- stale-data lock
+- disconnect lock
+- safe-mode veto
+- kill-switch veto
+- pre-trade veto taxonomy
+- scenario tests proving vetoes cannot be bypassed
+
+## What this adds
+
+- `RiskControlContext` for operator/runtime safety state.
+- `PreTradeVetoCode` taxonomy for operator-readable rejection reasons.
+- `PreTradeVeto` to carry structured veto sources.
+- RiskEngine integration while keeping existing arguments backward-compatible.
+- Tests for kill switch, safe mode, disconnect, stale data, daily loss, market cap, total exposure cap and extra veto injection.
+
+## Safety boundary
+
+This does not enable live order submission. It makes pre-trade gating stricter.
+
+## Expected validation
+
+```bash
+pytest -q tests/test_risk_engine.py
+```
+
+## Next patches
+
+1. Add a standalone kill-switch state machine with release protocol.
+2. Add capital ladder by stage: paper -> shadow -> testnet -> canary -> scaled-live.
+3. Wire risk-control context into execution guard and backend/API operator status.
+4. Add incident/log events for each veto source.

--- a/src/superajan12/agents/risk.py
+++ b/src/superajan12/agents/risk.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from superajan12.models import Decision, Market, OrderBookSnapshot, RiskDecision
+from superajan12.risk_controls import PreTradeVeto, PreTradeVetoCode, RiskControlContext, veto_reason
 
 
 class RiskEngine:
@@ -33,44 +34,101 @@ class RiskEngine:
         safe_mode: bool = False,
         reference_gate_ok: bool | None = None,
         reference_gate_reasons: list[str] | None = None,
+        control_context: RiskControlContext | None = None,
     ) -> RiskDecision:
+        context = control_context or RiskControlContext(
+            current_daily_pnl_usdc=current_daily_pnl_usdc,
+            safe_mode=safe_mode,
+        )
         reasons: list[str] = []
+        vetoes: list[PreTradeVeto] = []
 
-        if safe_mode:
-            reasons.append("safe-mode aktif; yeni islem yok")
+        if context.safe_mode:
+            vetoes.append(PreTradeVeto(PreTradeVetoCode.SAFE_MODE, "safe-mode aktif; yeni islem yok"))
 
-        if current_daily_pnl_usdc <= -abs(self.max_daily_loss_usdc):
-            reasons.append("gunluk zarar limiti dolmus")
+        if context.kill_switch_active:
+            vetoes.append(PreTradeVeto(PreTradeVetoCode.KILL_SWITCH, "kill-switch aktif; yeni islem yok"))
+
+        if not context.connected:
+            vetoes.append(PreTradeVeto(PreTradeVetoCode.DISCONNECTED, "baglanti yok; yeni islem yok"))
+
+        if context.market_data_stale:
+            vetoes.append(PreTradeVeto(PreTradeVetoCode.STALE_DATA, "piyasa verisi stale; yeni islem yok"))
+
+        if context.current_daily_pnl_usdc <= -abs(self.max_daily_loss_usdc):
+            vetoes.append(PreTradeVeto(PreTradeVetoCode.DAILY_LOSS_LIMIT, "gunluk zarar limiti dolmus"))
+
+        requested_risk = context.requested_risk_usdc
+        if requested_risk is None:
+            requested_risk = self.max_market_risk_usdc
+
+        if context.max_market_exposure_usdc is not None:
+            projected_market_exposure = context.current_market_exposure_usdc + max(requested_risk, 0.0)
+            if projected_market_exposure > context.max_market_exposure_usdc:
+                vetoes.append(
+                    PreTradeVeto(
+                        PreTradeVetoCode.POSITION_CAP,
+                        (
+                            "market exposure cap asilacak: "
+                            f"{projected_market_exposure:.2f} > {context.max_market_exposure_usdc:.2f} USDC"
+                        ),
+                    )
+                )
+
+        if context.max_total_exposure_usdc is not None:
+            projected_total_exposure = context.current_total_exposure_usdc + max(requested_risk, 0.0)
+            if projected_total_exposure > context.max_total_exposure_usdc:
+                vetoes.append(
+                    PreTradeVeto(
+                        PreTradeVetoCode.EXPOSURE_CAP,
+                        (
+                            "toplam exposure cap asilacak: "
+                            f"{projected_total_exposure:.2f} > {context.max_total_exposure_usdc:.2f} USDC"
+                        ),
+                    )
+                )
 
         if market.closed or not market.active:
-            reasons.append("market aktif degil")
+            vetoes.append(PreTradeVeto(PreTradeVetoCode.MARKET_INACTIVE, "market aktif degil"))
 
         if market.volume_usdc < self.min_volume_usdc:
-            reasons.append(
-                f"hacim dusuk: {market.volume_usdc:.2f} < {self.min_volume_usdc:.2f} USDC"
+            vetoes.append(
+                PreTradeVeto(
+                    PreTradeVetoCode.LOW_VOLUME,
+                    f"hacim dusuk: {market.volume_usdc:.2f} < {self.min_volume_usdc:.2f} USDC",
+                )
             )
 
         if market.liquidity_usdc < self.min_liquidity_usdc:
-            reasons.append(
-                f"likidite dusuk: {market.liquidity_usdc:.2f} < {self.min_liquidity_usdc:.2f} USDC"
+            vetoes.append(
+                PreTradeVeto(
+                    PreTradeVetoCode.LOW_LIQUIDITY,
+                    f"likidite dusuk: {market.liquidity_usdc:.2f} < {self.min_liquidity_usdc:.2f} USDC",
+                )
             )
 
         if order_book is None:
-            reasons.append("orderbook okunamadi")
+            vetoes.append(PreTradeVeto(PreTradeVetoCode.ORDERBOOK_UNAVAILABLE, "orderbook okunamadi"))
         else:
             if order_book.best_bid is None or order_book.best_ask is None:
-                reasons.append("orderbook eksik")
+                vetoes.append(PreTradeVeto(PreTradeVetoCode.ORDERBOOK_INCOMPLETE, "orderbook eksik"))
             elif order_book.spread_bps is None:
-                reasons.append("spread hesaplanamadi")
+                vetoes.append(PreTradeVeto(PreTradeVetoCode.SPREAD_UNAVAILABLE, "spread hesaplanamadi"))
             elif order_book.spread_bps > self.max_spread_bps:
-                reasons.append(
-                    f"spread genis: {order_book.spread_bps:.1f} bps > {self.max_spread_bps:.1f} bps"
+                vetoes.append(
+                    PreTradeVeto(
+                        PreTradeVetoCode.SPREAD_TOO_WIDE,
+                        f"spread genis: {order_book.spread_bps:.1f} bps > {self.max_spread_bps:.1f} bps",
+                    )
                 )
 
         if reference_gate_ok is False:
-            reasons.append("referans fiyat kapisi reddetti")
+            vetoes.append(PreTradeVeto(PreTradeVetoCode.REFERENCE_GATE, "referans fiyat kapisi reddetti"))
             if reference_gate_reasons:
                 reasons.extend(reference_gate_reasons)
+
+        vetoes.extend(context.extra_vetoes)
+        reasons = [veto_reason(veto.code, veto.reason) for veto in vetoes] + reasons
 
         if reasons:
             return RiskDecision(decision=Decision.REJECT, max_risk_usdc=0.0, reasons=reasons)

--- a/src/superajan12/risk_controls.py
+++ b/src/superajan12/risk_controls.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class PreTradeVetoCode(str, Enum):
+    SAFE_MODE = "safe_mode"
+    KILL_SWITCH = "kill_switch"
+    DISCONNECTED = "disconnected"
+    STALE_DATA = "stale_data"
+    DAILY_LOSS_LIMIT = "daily_loss_limit"
+    POSITION_CAP = "position_cap"
+    EXPOSURE_CAP = "exposure_cap"
+    MARKET_INACTIVE = "market_inactive"
+    LOW_VOLUME = "low_volume"
+    LOW_LIQUIDITY = "low_liquidity"
+    ORDERBOOK_UNAVAILABLE = "orderbook_unavailable"
+    ORDERBOOK_INCOMPLETE = "orderbook_incomplete"
+    SPREAD_UNAVAILABLE = "spread_unavailable"
+    SPREAD_TOO_WIDE = "spread_too_wide"
+    REFERENCE_GATE = "reference_gate"
+
+
+@dataclass(frozen=True)
+class PreTradeVeto:
+    code: PreTradeVetoCode
+    reason: str
+
+
+@dataclass(frozen=True)
+class RiskControlContext:
+    current_daily_pnl_usdc: float = 0.0
+    safe_mode: bool = False
+    kill_switch_active: bool = False
+    connected: bool = True
+    market_data_stale: bool = False
+    current_market_exposure_usdc: float = 0.0
+    current_total_exposure_usdc: float = 0.0
+    requested_risk_usdc: float | None = None
+    max_market_exposure_usdc: float | None = None
+    max_total_exposure_usdc: float | None = None
+    extra_vetoes: tuple[PreTradeVeto, ...] = field(default_factory=tuple)
+
+    @property
+    def requested_risk_or_zero(self) -> float:
+        if self.requested_risk_usdc is None:
+            return 0.0
+        return max(self.requested_risk_usdc, 0.0)
+
+
+def veto_reason(code: PreTradeVetoCode, detail: str) -> str:
+    return f"{code.value}: {detail}"

--- a/tests/test_risk_engine.py
+++ b/tests/test_risk_engine.py
@@ -1,5 +1,6 @@
 from superajan12.agents.risk import RiskEngine
 from superajan12.models import Decision, Market, OrderBookLevel, OrderBookSnapshot
+from superajan12.risk_controls import PreTradeVeto, PreTradeVetoCode, RiskControlContext
 
 
 def make_engine() -> RiskEngine:
@@ -12,29 +13,105 @@ def make_engine() -> RiskEngine:
     )
 
 
-def test_risk_engine_rejects_low_volume_market() -> None:
-    market = Market(id="1", question="Test?", volume_usdc=10, liquidity_usdc=500)
-    book = OrderBookSnapshot(
+def make_market() -> Market:
+    return Market(id="1", question="Test?", volume_usdc=5000, liquidity_usdc=1000)
+
+
+def make_book() -> OrderBookSnapshot:
+    return OrderBookSnapshot(
         market_id="1",
         yes_bids=[OrderBookLevel(price=0.49, size=100)],
         yes_asks=[OrderBookLevel(price=0.51, size=100)],
     )
 
-    decision = make_engine().evaluate_market(market, book)
+
+def test_risk_engine_rejects_low_volume_market() -> None:
+    market = Market(id="1", question="Test?", volume_usdc=10, liquidity_usdc=500)
+    decision = make_engine().evaluate_market(market, make_book())
 
     assert decision.decision == Decision.REJECT
-    assert any("hacim dusuk" in reason for reason in decision.reasons)
+    assert any("low_volume" in reason and "hacim dusuk" in reason for reason in decision.reasons)
 
 
 def test_risk_engine_approves_clean_market() -> None:
-    market = Market(id="1", question="Test?", volume_usdc=5000, liquidity_usdc=1000)
-    book = OrderBookSnapshot(
-        market_id="1",
-        yes_bids=[OrderBookLevel(price=0.49, size=100)],
-        yes_asks=[OrderBookLevel(price=0.51, size=100)],
-    )
-
-    decision = make_engine().evaluate_market(market, book)
+    decision = make_engine().evaluate_market(make_market(), make_book())
 
     assert decision.decision == Decision.APPROVE
     assert decision.max_risk_usdc == 10
+
+
+def test_risk_engine_rejects_kill_switch_safe_mode_and_disconnect() -> None:
+    context = RiskControlContext(
+        safe_mode=True,
+        kill_switch_active=True,
+        connected=False,
+    )
+
+    decision = make_engine().evaluate_market(make_market(), make_book(), control_context=context)
+
+    assert decision.decision == Decision.REJECT
+    assert any("safe_mode" in reason for reason in decision.reasons)
+    assert any("kill_switch" in reason for reason in decision.reasons)
+    assert any("disconnected" in reason for reason in decision.reasons)
+
+
+def test_risk_engine_rejects_stale_data() -> None:
+    context = RiskControlContext(market_data_stale=True)
+
+    decision = make_engine().evaluate_market(make_market(), make_book(), control_context=context)
+
+    assert decision.decision == Decision.REJECT
+    assert any("stale_data" in reason for reason in decision.reasons)
+
+
+def test_risk_engine_rejects_daily_loss_limit_from_context() -> None:
+    context = RiskControlContext(current_daily_pnl_usdc=-25)
+
+    decision = make_engine().evaluate_market(make_market(), make_book(), control_context=context)
+
+    assert decision.decision == Decision.REJECT
+    assert any("daily_loss_limit" in reason for reason in decision.reasons)
+
+
+def test_risk_engine_rejects_market_position_cap() -> None:
+    context = RiskControlContext(
+        current_market_exposure_usdc=95,
+        requested_risk_usdc=10,
+        max_market_exposure_usdc=100,
+    )
+
+    decision = make_engine().evaluate_market(make_market(), make_book(), control_context=context)
+
+    assert decision.decision == Decision.REJECT
+    assert any("position_cap" in reason for reason in decision.reasons)
+
+
+def test_risk_engine_rejects_total_exposure_cap() -> None:
+    context = RiskControlContext(
+        current_total_exposure_usdc=995,
+        requested_risk_usdc=10,
+        max_total_exposure_usdc=1000,
+    )
+
+    decision = make_engine().evaluate_market(make_market(), make_book(), control_context=context)
+
+    assert decision.decision == Decision.REJECT
+    assert any("exposure_cap" in reason for reason in decision.reasons)
+
+
+def test_risk_engine_rejects_extra_vetoes() -> None:
+    context = RiskControlContext(
+        extra_vetoes=(PreTradeVeto(PreTradeVetoCode.KILL_SWITCH, "operator forced halt"),)
+    )
+
+    decision = make_engine().evaluate_market(make_market(), make_book(), control_context=context)
+
+    assert decision.decision == Decision.REJECT
+    assert any("operator forced halt" in reason for reason in decision.reasons)
+
+
+def test_risk_engine_keeps_backward_compatible_safe_mode_argument() -> None:
+    decision = make_engine().evaluate_market(make_market(), make_book(), safe_mode=True)
+
+    assert decision.decision == Decision.REJECT
+    assert any("safe_mode" in reason for reason in decision.reasons)


### PR DESCRIPTION
## What changed
- Added 200-agent execution board for the larger remaining work program.
- Added structured `RiskControlContext`, `PreTradeVeto`, and `PreTradeVetoCode` taxonomy.
- Hardened `RiskEngine` with explicit vetoes for safe mode, kill switch, disconnect, stale data, daily loss, market exposure cap, total exposure cap, and extra veto injection.
- Expanded risk-engine scenario tests while keeping backward-compatible safe-mode/current-PnL arguments.
- Documented the risk/capital/kill-switch hardening batch.

## Safety boundary
- This makes pre-trade gating stricter.
- No live order sending is enabled.
- No secrets, credentials, signing, or account access are added.

## Validation
- Added/updated `tests/test_risk_engine.py`.
- Expected command: `pytest -q tests/test_risk_engine.py`.

## Roadmap link
Advances #25 by strengthening the risk / capital / kill-switch layer needed for 40/100 -> 45/100 readiness.