### PR TITLE
[codex] Document agent loop orchestration queue

### DIFF
--- a/docs/ACTIVE_EXECUTION_QUEUE.md
+++ b/docs/ACTIVE_EXECUTION_QUEUE.md
@@ -8,6 +8,42 @@ This file is the live queue for the 14-item execution wave. "Started" here means
 - current blocker is identified where one exists
 - next technical move is defined
 
+## Agent loop - 2026-05-04
+
+Goal: keep the 100/100 readiness push moving through small, auditable agent-style work cycles.
+
+### Active agents
+
+| Agent | Current focus | Output this cycle | Next action |
+| --- | --- | --- | --- |
+| Repo agent | Repository and PR state | Confirmed `gokhanaydinn16/superajan12` access and open PR set: #29, #38, #39 | Keep PR inventory fresh before every merge attempt |
+| CI agent | Required checks | Confirmed CI success on #29, #38, and #39 head commits | Recheck after every head movement |
+| Safety agent | #32 risk/live gates | Prioritized #38 safety-state persistence and #39 reconciliation false-green removal | Land draft PRs once ready-for-review state is cleared |
+| Release agent | #37 CI/release gates | Prioritized #29 workflow/release hardening | Land #29 after draft state is cleared |
+| Orchestration agent | Continuous sprint board | Added this loop to the persistent execution queue | Continue with small PRs instead of broad unsafe rewrites |
+
+### Current blockers found by the agents
+
+- #29 is mergeable and CI-successful, but still draft.
+- #38 is mergeable and CI-successful, but still draft.
+- #39 is mergeable and CI-successful, but still draft.
+- Connector attempt to mark draft PRs ready for review failed because the GitHub GraphQL response shape exposed an unsupported `htmlUrl` field in the tool wrapper.
+- Direct merge attempts are blocked by GitHub while the PRs remain draft.
+
+### Sprint order
+
+1. Mark #38 ready and squash-merge: persisted safety state across restarts.
+2. Mark #39 ready and squash-merge: block synthetic reconciliation readiness pass.
+3. Mark #29 ready and squash-merge: repo workflow, smoke, and release-compliance hardening.
+4. After those land, create the next #32 patch for explicit reconciliation incident events.
+5. Then create the next #37 patch for artifact integrity/provenance checks.
+
+### Safety boundary
+
+- No live order submission.
+- No secrets, credentials, signing keys, or account access.
+- No live adapter implementation beyond dry-run and readiness gates until phases 1-13 are satisfied.
+
 ## 1. Tauri native build chain
 
 - Status: started


### PR DESCRIPTION
## What changed
- Added an Agent loop section to `docs/ACTIVE_EXECUTION_QUEUE.md`.
- Captures active agent roles, current PR blockers, and the next sprint order.
- Records that #29, #38, and #39 are CI-successful and mergeable but blocked by draft state.

## Why
- The 100/100 readiness push needs a visible, durable work queue instead of ad hoc chat-only coordination.
- This gives the operator a repo-native place to inspect what each agent lane is doing and what the next safe action is.

## Safety boundary
- Documentation/orchestration only.
- No live order submission.
- No secrets, credentials, signing keys, or account access.

## Next after this PR
1. Mark #38 ready and merge.
2. Mark #39 ready and merge.
3. Mark #29 ready and merge.
4. Start the next #32 patch for reconciliation incident events.
5. Start the next #37 patch for artifact integrity/provenance checks.