### PR TITLE
[codex] Persist safety state across restarts

### DIFF
--- a/src/superajan12/safety.py
+++ b/src/superajan12/safety.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
-from functools import lru_cache
+from pathlib import Path
+
+from superajan12.config import get_settings
 
 
 @dataclass(frozen=True)
@@ -20,11 +23,13 @@ class SafetyState:
 class SafetyController:
     """Central safe-mode / kill-switch controller.
 
-    Phase 1 is in-memory and conservative. Later phases will persist incidents,
-    connect alerts, and enforce this state inside live execution.
+    The controller now persists state to a small runtime file so safety locks
+    survive process restarts. Later phases can add richer release protocol and
+    incident lifecycle behavior on top of this durable baseline.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, state_path: Path | None = None) -> None:
+        self._state_path = state_path
         self._safe_mode = False
         self._kill_switch = False
         self._stale_data_lock = False
@@ -33,10 +38,12 @@ class SafetyController:
         self._kill_switch_reason: str | None = None
         self._stale_data_reason: str | None = None
         self._disconnect_reason: str | None = None
+        self._load_state()
 
     def enable_safe_mode(self, reason: str) -> None:
         self._safe_mode = True
         self._safe_mode_reason = reason
+        self._persist_state()
 
     def enable_kill_switch(self, reason: str) -> None:
         self._kill_switch = True
@@ -44,14 +51,17 @@ class SafetyController:
         if not self._safe_mode:
             self._safe_mode = True
             self._safe_mode_reason = "kill-switch enabled"
+        self._persist_state()
 
     def enable_stale_data_lock(self, reason: str) -> None:
         self._stale_data_lock = True
         self._stale_data_reason = reason
+        self._persist_state()
 
     def clear_stale_data_lock(self) -> None:
         self._stale_data_lock = False
         self._stale_data_reason = None
+        self._persist_state()
 
     def enable_disconnect_lock(self, reason: str) -> None:
         self._disconnect_lock = True
@@ -59,6 +69,7 @@ class SafetyController:
         if not self._safe_mode:
             self._safe_mode = True
             self._safe_mode_reason = "disconnect lock enabled"
+        self._persist_state()
 
     def clear_disconnect_lock(self) -> None:
         self._disconnect_lock = False
@@ -66,6 +77,7 @@ class SafetyController:
         if self._safe_mode and self._safe_mode_reason == "disconnect lock enabled":
             self._safe_mode = False
             self._safe_mode_reason = None
+        self._persist_state()
 
     def clear_safe_mode(self) -> None:
         self._safe_mode = False
@@ -76,6 +88,7 @@ class SafetyController:
         self._kill_switch_reason = None
         self._stale_data_reason = None
         self._disconnect_reason = None
+        self._persist_state()
 
     def disable_kill_switch(self) -> None:
         self._kill_switch = False
@@ -83,6 +96,7 @@ class SafetyController:
         if self._safe_mode and self._safe_mode_reason == "kill-switch enabled":
             self._safe_mode = False
             self._safe_mode_reason = None
+        self._persist_state()
 
     def state(self) -> SafetyState:
         reasons = tuple(
@@ -103,7 +117,55 @@ class SafetyController:
             reasons=reasons,
         )
 
+    def _load_state(self) -> None:
+        if self._state_path is None or not self._state_path.exists():
+            return
+        try:
+            payload = json.loads(self._state_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return
 
-@lru_cache(maxsize=1)
+        self._safe_mode = bool(payload.get("safe_mode", False))
+        self._kill_switch = bool(payload.get("kill_switch", False))
+        self._stale_data_lock = bool(payload.get("stale_data_lock", False))
+        self._disconnect_lock = bool(payload.get("disconnect_lock", False))
+        self._safe_mode_reason = _optional_text(payload.get("safe_mode_reason"))
+        self._kill_switch_reason = _optional_text(payload.get("kill_switch_reason"))
+        self._stale_data_reason = _optional_text(payload.get("stale_data_reason"))
+        self._disconnect_reason = _optional_text(payload.get("disconnect_reason"))
+
+    def _persist_state(self) -> None:
+        if self._state_path is None:
+            return
+        self._state_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "safe_mode": self._safe_mode,
+            "kill_switch": self._kill_switch,
+            "stale_data_lock": self._stale_data_lock,
+            "disconnect_lock": self._disconnect_lock,
+            "safe_mode_reason": self._safe_mode_reason,
+            "kill_switch_reason": self._kill_switch_reason,
+            "stale_data_reason": self._stale_data_reason,
+            "disconnect_reason": self._disconnect_reason,
+        }
+        self._state_path.write_text(json.dumps(payload, ensure_ascii=True, indent=2), encoding="utf-8")
+
+
 def get_safety_controller() -> SafetyController:
-    return SafetyController()
+    state_path = get_settings().sqlite_path.with_name("safety_state.json")
+    key = str(state_path.resolve())
+    controller = _SAFETY_CONTROLLERS.get(key)
+    if controller is None:
+        controller = SafetyController(state_path)
+        _SAFETY_CONTROLLERS[key] = controller
+    return controller
+
+
+def _optional_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+_SAFETY_CONTROLLERS: dict[str, SafetyController] = {}

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from superajan12.safety import SafetyController
 
 
@@ -57,3 +59,34 @@ def test_safety_controller_tracks_stale_and_disconnect_locks() -> None:
     assert cleared.stale_data_lock is False
     assert cleared.disconnect_lock is False
     assert cleared.can_open_new_positions is True
+
+
+def test_safety_controller_persists_state_across_instances(tmp_path: Path) -> None:
+    state_path = tmp_path / "safety_state.json"
+
+    writer = SafetyController(state_path)
+    writer.enable_kill_switch("manual emergency stop")
+    writer.enable_stale_data_lock("stale feed")
+
+    reader = SafetyController(state_path)
+    state = reader.state()
+
+    assert state.kill_switch is True
+    assert state.safe_mode is True
+    assert state.stale_data_lock is True
+    assert "manual emergency stop" in state.reasons
+    assert state_path.exists() is True
+
+
+def test_safety_controller_clear_persists_reset_state(tmp_path: Path) -> None:
+    state_path = tmp_path / "safety_state.json"
+
+    controller = SafetyController(state_path)
+    controller.enable_safe_mode("operator pause")
+    controller.enable_kill_switch("manual emergency stop")
+    controller.clear_safe_mode()
+
+    reloaded = SafetyController(state_path).state()
+    assert reloaded.safe_mode is False
+    assert reloaded.kill_switch is False
+    assert reloaded.reasons == ()


### PR DESCRIPTION
Replacement for draft PR #38 because the draft-to-ready connector transition is currently failing upstream.

## What changed
- Persisted `SafetyController` state to a runtime safety-state file so kill-switch, safe-mode, stale-data lock, and disconnect lock survive process restarts.
- Made `get_safety_controller()` resolve controllers by current runtime database path instead of a single global singleton.
- Added regression tests proving safety state persists across controller instances and that clearing state also persists.

## Why
- `main` previously kept safety state only in memory.
- That meant a process restart could accidentally drop kill-switch or safe-mode state and create false readiness.
- This patch closes that gap without widening live-trading behavior.

## Safety boundary
- No live order sending is enabled.
- No secrets or account access are added.
- This only makes existing safety locks durable.

## Validation
- Added `tests/test_safety.py` coverage for persistence and reset behavior.
- Expected command: `pytest -q tests/test_safety.py`.

## Roadmap link
Advances #32 by closing the restart-state-loss risk before the later release-protocol and reconciliation patches.