### PR TITLE
[codex] Block synthetic reconciliation readiness pass

### DIFF
--- a/src/superajan12/backend_api.py
+++ b/src/superajan12/backend_api.py
@@ -385,10 +385,7 @@ def create_backend_app() -> FastAPI:
         secret_refs = [secret_manager.has_secret(name) for name in required_secret_names]
         secrets_ready = all(secret.present for secret in secret_refs)
         local_open_positions = len(store.list_open_positions())
-        reconciliation = ReconciliationAgent().compare_counts(
-            local_open_positions=local_open_positions,
-            external_open_positions=local_open_positions,
-        )
+        reconciliation = ReconciliationAgent().blocking_placeholder()
         readiness = _build_micro_live_readiness(
             store=store,
             strategy_payload=strategy_payload,

--- a/src/superajan12/reconciliation.py
+++ b/src/superajan12/reconciliation.py
@@ -25,3 +25,12 @@ class ReconciliationAgent:
                 ),
             )
         return ReconciliationResult(ok=True, reasons=("position counts match",))
+
+    def blocking_placeholder(self) -> ReconciliationResult:
+        return ReconciliationResult(
+            ok=False,
+            reasons=(
+                "live reconciliation is not wired to a real venue yet",
+                "blocking live readiness until external positions and orders are checked",
+            ),
+        )

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -102,6 +102,8 @@ def test_backend_command_center_endpoints_have_expected_shapes() -> None:
     assert "secrets" in execution_payload
     assert "guard" in execution_payload
     assert execution_payload["live_trading"] == "disabled"
+    assert execution_payload["reconciliation"]["ok"] is False
+    assert any("not wired" in reason for reason in execution_payload["reconciliation"]["reasons"])
 
     assert system_health.status_code == 200
     system_payload = system_health.json()


### PR DESCRIPTION
Replacement for draft PR #39 because the draft-to-ready connector transition is currently failing upstream.

## What changed
- Added a blocking reconciliation placeholder result for live readiness until external venue reconciliation is wired for real.
- Updated `/execution/status` so it no longer marks reconciliation as passed by comparing local counts to themselves.
- Added backend API coverage proving execution status now reports reconciliation as blocked instead of green.

## Why
- `main` previously produced a synthetic reconciliation pass by setting `external_open_positions = local_open_positions`.
- That created false readiness and could hide real external mismatch risk.
- This patch fails closed until real venue-backed reconciliation exists.

## Safety boundary
- No live order sending is enabled.
- No secrets or credentials are added.
- This only removes a misleading green light from the operator/readiness surface.

## Validation
- Updated `tests/test_backend_api.py`.
- Expected command: `pytest -q tests/test_backend_api.py`.

## Roadmap link
Advances #32 by removing the false-green reconciliation path before the real reconciliation implementation lands.