### PR TITLE
[codex] Harden repository workspace and developer workflow

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,34 @@ jobs:
       - name: Runtime compatibility test
         run: PYTHONPATH=src python -m pytest -q
 
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Offline smoke validation
+        run: make smoke
+
+  release-compliance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Validate release surface parity
+        run: bash scripts/release-compliance.sh
+
   desktop-web:
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,44 @@ permissions:
   contents: write
 
 jobs:
+  release-compliance:
+    runs-on: ubuntu-latest
+    outputs:
+      target_version: ${{ steps.meta.outputs.target_version }}
+      tag: ${{ steps.meta.outputs.tag }}
+      name: ${{ steps.meta.outputs.name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Resolve release metadata
+        id: meta
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            echo "target_version=${{ inputs.release_version }}" >> "$GITHUB_OUTPUT"
+            echo "tag=v${{ inputs.release_version }}" >> "$GITHUB_OUTPUT"
+            echo "name=SuperAjan12 v${{ inputs.release_version }}" >> "$GITHUB_OUTPUT"
+          else
+            target_version="${GITHUB_REF_NAME#v}"
+            echo "target_version=${target_version}" >> "$GITHUB_OUTPUT"
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            echo "name=SuperAjan12 ${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate release surface parity and changelog
+        env:
+          TARGET_VERSION: ${{ steps.meta.outputs.target_version }}
+        run: bash scripts/release-compliance.sh
+
   build-python:
     runs-on: ubuntu-latest
+    needs:
+      - release-compliance
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,6 +76,8 @@ jobs:
 
   build-desktop-web:
     runs-on: ubuntu-latest
+    needs:
+      - release-compliance
     defaults:
       run:
         working-directory: apps/desktop
@@ -67,22 +105,12 @@ jobs:
   publish-release:
     runs-on: ubuntu-latest
     needs:
+      - release-compliance
       - build-python
       - build-desktop-web
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Resolve release tag
-        id: meta
-        run: |
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            echo "tag=v${{ inputs.release_version }}" >> "$GITHUB_OUTPUT"
-            echo "name=SuperAjan12 v${{ inputs.release_version }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
-            echo "name=SuperAjan12 ${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Download Python artifacts
         uses: actions/download-artifact@v4
@@ -99,8 +127,8 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.meta.outputs.tag }}
-          name: ${{ steps.meta.outputs.name }}
+          tag_name: ${{ needs.release-compliance.outputs.tag }}
+          name: ${{ needs.release-compliance.outputs.name }}
           body: |
             Release notes are maintained in `CHANGELOG.md`.
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,12 +7,21 @@ __pycache__/
 .ruff_cache/
 .venv/
 venv/
+.coverage
+htmlcov/
+build/
+dist/
 
 # Local runtime data
 .env
 data/
 *.sqlite3
 *.db
+
+# Desktop / frontend
+apps/desktop/node_modules/
+apps/desktop/dist/
+apps/desktop/src-tauri/target/
 
 # OS/editor
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ The format is based on Keep a Changelog, and this repository follows semantic ve
 ### Added
 - A root `Makefile` with stable developer entrypoints for bootstrap, validation, smoke checks, backend startup, and web startup.
 - `scripts/bootstrap.sh`, `scripts/check.sh`, and `scripts/smoke.sh` to make local setup and repeat validation more repeatable.
+- `scripts/release-compliance.sh` to verify version parity and release-heading discipline before publication.
 - `CONTRIBUTING.md`, `docs/DEVELOPMENT.md`, and `.editorconfig` so repo usage and formatting expectations are explicit.
 
 ### Changed
 - Expanded `.gitignore` to cover local build outputs, coverage artifacts, and desktop dependency/build directories.
 - Updated `README.md` with the preferred developer workflow and command map.
+- Added `smoke` and `release-compliance` CI lanes, and made the release workflow stop before publish when version/changelog checks fail.
 
 ## [0.2.0] - 2026-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this repository follows semantic versioning for the Python package, desktop shell, and release tags.
 
+## [Unreleased]
+
+### Added
+- A root `Makefile` with stable developer entrypoints for bootstrap, validation, smoke checks, backend startup, and web startup.
+- `scripts/bootstrap.sh`, `scripts/check.sh`, and `scripts/smoke.sh` to make local setup and repeat validation more repeatable.
+- `CONTRIBUTING.md`, `docs/DEVELOPMENT.md`, and `.editorconfig` so repo usage and formatting expectations are explicit.
+
+### Changed
+- Expanded `.gitignore` to cover local build outputs, coverage artifacts, and desktop dependency/build directories.
+- Updated `README.md` with the preferred developer workflow and command map.
+
 ## [0.2.0] - 2026-05-03
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing
+
+## Goal
+
+Keep SuperAjan12 easy to run, easy to validate, and hard to accidentally weaken.
+
+## Ground rules
+
+- Default to paper and shadow workflows.
+- Do not add live order submission by default.
+- Do not commit secrets, runtime databases, or audit logs.
+- Prefer focused pull requests with a clear validation path.
+- Update docs when behavior, commands, or operational expectations change.
+
+## Local setup
+
+Recommended path:
+
+```bash
+make bootstrap
+make check
+make smoke
+```
+
+Fallback path for constrained environments:
+
+```bash
+make bootstrap-compat
+bash scripts/check.sh compat
+bash scripts/smoke.sh
+```
+
+## Validation lanes
+
+Use these commands before opening or merging a PR:
+
+```bash
+make lint
+make test
+make test-compat
+make smoke
+```
+
+Network-backed checks are intentionally separate:
+
+```bash
+make verify-endpoints
+make reference-check
+```
+
+## Documentation touch points
+
+When you change developer workflow, release flow, or operator expectations, review these files too:
+
+- `README.md`
+- `docs/DEVELOPMENT.md`
+- `docs/STATUS.md`
+- `docs/HANDOFF.md`
+- `docs/RUNBOOK.md`
+- `docs/RELEASE.md`
+- `CHANGELOG.md`
+
+## Pull request expectations
+
+A good PR should state:
+
+1. What changed.
+2. Why it changed.
+3. Safety boundary, especially if runtime or execution code is touched.
+4. Validation commands used.
+5. Follow-up work left visible.
+
+## Preferred change shape
+
+- Keep changes rollback-friendly.
+- Reuse existing repo patterns before inventing new abstractions.
+- Add tests when behavior changes.
+- If full runtime dependencies are unavailable, keep the runtime-compat lane green.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,63 @@
+SHELL := /usr/bin/env bash
+.DEFAULT_GOAL := help
+
+PYTHON ?= python3
+VENV_DIR ?= .venv
+VENV_PYTHON := $(VENV_DIR)/bin/python
+VENV_PIP := $(VENV_DIR)/bin/pip
+
+.PHONY: help bootstrap bootstrap-compat init-db lint test test-compat check smoke verify-endpoints reference-check run-backend run-web
+
+help:
+	@printf '%s\n' \
+	  'Available targets:' \
+	  '  make bootstrap         Create .venv, install dev deps, copy .env.example when needed, init DB' \
+	  '  make bootstrap-compat  Minimal local fallback bootstrap without package install' \
+	  '  make init-db           Initialize or migrate the local SQLite schema' \
+	  '  make lint              Run Ruff on src/ and tests/' \
+	  '  make test              Run installed-dependency pytest lane' \
+	  '  make test-compat       Run repository runtime-compat pytest lane' \
+	  '  make check             Run lint + both pytest lanes' \
+	  '  make smoke             Run offline CLI smoke checks' \
+	  '  make verify-endpoints  Verify Polymarket public endpoints' \
+	  '  make reference-check   Cross-check BTC/ETH/SOL reference prices' \
+	  '  make run-backend       Start local backend API on 127.0.0.1:8000' \
+	  '  make run-web           Start the web dashboard entrypoint'
+
+bootstrap:
+	bash scripts/bootstrap.sh
+
+bootstrap-compat:
+	@if [ ! -d "$(VENV_DIR)" ]; then $(PYTHON) -m venv "$(VENV_DIR)"; fi
+	@if [ ! -f .env ] && [ -f .env.example ]; then cp .env.example .env; fi
+	PYTHONPATH=src $(PYTHON) -m superajan12.cli init-db
+
+init-db:
+	$(VENV_PYTHON) -m superajan12.cli init-db
+
+lint:
+	$(VENV_PYTHON) -m ruff check src tests
+
+test:
+	$(VENV_PYTHON) -m pytest -q -o pythonpath=
+
+test-compat:
+	PYTHONPATH=src $(PYTHON) -m pytest -q
+
+check:
+	bash scripts/check.sh
+
+smoke:
+	bash scripts/smoke.sh
+
+verify-endpoints:
+	$(VENV_PYTHON) -m superajan12.cli verify-endpoints
+
+reference-check:
+	$(VENV_PYTHON) -m superajan12.cli reference-check --symbols BTC,ETH,SOL
+
+run-backend:
+	PYTHONPATH=src $(PYTHON) -m superajan12.backend_server --host 127.0.0.1 --port 8000
+
+run-web:
+	$(VENV_PYTHON) -m superajan12.web

--- a/Makefile
+++ b/Makefile
@@ -6,23 +6,24 @@ VENV_DIR ?= .venv
 VENV_PYTHON := $(VENV_DIR)/bin/python
 VENV_PIP := $(VENV_DIR)/bin/pip
 
-.PHONY: help bootstrap bootstrap-compat init-db lint test test-compat check smoke verify-endpoints reference-check run-backend run-web
+.PHONY: help bootstrap bootstrap-compat init-db lint test test-compat check smoke release-compliance verify-endpoints reference-check run-backend run-web
 
 help:
 	@printf '%s\n' \
 	  'Available targets:' \
-	  '  make bootstrap         Create .venv, install dev deps, copy .env.example when needed, init DB' \
-	  '  make bootstrap-compat  Minimal local fallback bootstrap without package install' \
-	  '  make init-db           Initialize or migrate the local SQLite schema' \
-	  '  make lint              Run Ruff on src/ and tests/' \
-	  '  make test              Run installed-dependency pytest lane' \
-	  '  make test-compat       Run repository runtime-compat pytest lane' \
-	  '  make check             Run lint + both pytest lanes' \
-	  '  make smoke             Run offline CLI smoke checks' \
-	  '  make verify-endpoints  Verify Polymarket public endpoints' \
-	  '  make reference-check   Cross-check BTC/ETH/SOL reference prices' \
-	  '  make run-backend       Start local backend API on 127.0.0.1:8000' \
-	  '  make run-web           Start the web dashboard entrypoint'
+	  '  make bootstrap           Create .venv, install dev deps, copy .env.example when needed, init DB' \
+	  '  make bootstrap-compat    Minimal local fallback bootstrap without package install' \
+	  '  make init-db             Initialize or migrate the local SQLite schema' \
+	  '  make lint                Run Ruff on src/ and tests/' \
+	  '  make test                Run installed-dependency pytest lane' \
+	  '  make test-compat         Run repository runtime-compat pytest lane' \
+	  '  make check               Run lint + both pytest lanes' \
+	  '  make smoke               Run offline CLI smoke checks' \
+	  '  make release-compliance  Verify version parity and changelog release discipline' \
+	  '  make verify-endpoints    Verify Polymarket public endpoints' \
+	  '  make reference-check     Cross-check BTC/ETH/SOL reference prices' \
+	  '  make run-backend         Start local backend API on 127.0.0.1:8000' \
+	  '  make run-web             Start the web dashboard entrypoint'
 
 bootstrap:
 	bash scripts/bootstrap.sh
@@ -49,6 +50,9 @@ check:
 
 smoke:
 	bash scripts/smoke.sh
+
+release-compliance:
+	bash scripts/release-compliance.sh
 
 verify-endpoints:
 	$(VENV_PYTHON) -m superajan12.cli verify-endpoints

--- a/README.md
+++ b/README.md
@@ -97,6 +97,16 @@ Ilk asamada canli emir yoktur. Varsayilan mod `paper` modudur.
 
 ## Kurulum
 
+Hizli ve tercih edilen yol:
+
+```bash
+make bootstrap
+make check
+make smoke
+```
+
+Elle kurulum yapmak istersen:
+
 ```bash
 python -m venv .venv
 source .venv/bin/activate
@@ -113,6 +123,31 @@ superajan12 verify-endpoints
 superajan12 reference-check --symbols BTC,ETH,SOL,XRP,DOGE
 superajan12 scan --limit 25
 superajan12 report
+```
+
+## Gelistirici komut haritasi
+
+Gelistirme akisinin tek yerden yonetilmesi icin root `Makefile` eklendi.
+
+```bash
+make bootstrap
+make lint
+make test
+make test-compat
+make check
+make smoke
+make verify-endpoints
+make reference-check
+make run-backend
+make run-web
+```
+
+Ortam kisitliysa fallback yol:
+
+```bash
+make bootstrap-compat
+bash scripts/check.sh compat
+bash scripts/smoke.sh
 ```
 
 Ek guvenlik/ogrenme komutlari:
@@ -158,6 +193,8 @@ PYTHONPATH=src python -m pytest -q
 ```
 
 Bu fallback yol, Python paketleri veya Rust/Node araclari hazir olmadiginda repo icindeki hafif uyumluluk katmani ile backend ve test yuzeyini ayakta tutar.
+
+Daha detayli yerel akis icin: `docs/DEVELOPMENT.md`
 
 ## Local ciktilar
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,82 @@
+# SuperAjan12 Development Guide
+
+## Purpose
+
+This guide makes the repository easier to re-enter, validate, and extend without re-discovering the local workflow each time.
+
+## Recommended local workflow
+
+```bash
+make bootstrap
+make check
+make smoke
+```
+
+What this gives you:
+
+- a local virtual environment in `.venv`
+- dev dependencies installed
+- `.env` created from `.env.example` when available
+- local SQLite schema initialized
+- lint, test, and offline smoke commands ready to run
+
+## Constrained environment workflow
+
+If package installation or registry access is blocked, use the repository fallback path:
+
+```bash
+make bootstrap-compat
+bash scripts/check.sh compat
+bash scripts/smoke.sh
+```
+
+This path keeps the Python source tree and local compatibility modules usable even when full dependency setup is unavailable.
+
+## Command map
+
+### Core validation
+
+```bash
+make lint
+make test
+make test-compat
+make check
+make smoke
+```
+
+### Network-backed validation
+
+```bash
+make verify-endpoints
+make reference-check
+```
+
+### Runtime entrypoints
+
+```bash
+make run-backend
+make run-web
+```
+
+## When to use each lane
+
+- `make test`: use when the package is installed into `.venv` and you want the real dependency lane.
+- `make test-compat`: use when you need to prove the repository's fallback runtime still works.
+- `make check`: use before PRs or when touching shared code paths.
+- `make smoke`: use for quick confidence that the local CLI/reporting surfaces still start and query storage.
+
+## Working agreements for future changes
+
+- Prefer adding one stable entrypoint over many ad hoc shell snippets.
+- Keep offline checks available whenever possible.
+- Keep network-dependent checks explicit so failures are easier to diagnose.
+- Document new commands in the Makefile and README at the same time.
+- If an implementation changes operator expectations, update `docs/RUNBOOK.md` and `docs/PRODUCTION_CHECKLIST.md` too.
+
+## Suggested first commands after pulling new changes
+
+```bash
+make bootstrap
+make smoke
+make check
+```

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -35,8 +35,19 @@ SuperAjan12 is ready for paper/shadow operation. It is not a live trading bot an
 27. Runbook and production checklist.
 28. Desktop/backend constrained-runtime fallback path.
 29. Release workflow, changelog, and versioning policy.
+30. Stable local developer entrypoints via Makefile and helper scripts.
 
 ## Main commands
+
+Recommended local entrypoint:
+
+```bash
+make bootstrap
+make check
+make smoke
+```
+
+Core CLI commands:
 
 ```bash
 superajan12 init-db
@@ -57,7 +68,9 @@ superajan12 execution-check --mode paper
 Fallback validation commands when package/toolchain setup is blocked:
 
 ```bash
-PYTHONPATH=src python -m pytest -q
+make bootstrap-compat
+bash scripts/check.sh compat
+bash scripts/smoke.sh
 PYTHONPATH=src python -m superajan12.backend_server --host 127.0.0.1 --port 8000
 ```
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -25,6 +25,7 @@ Required release-entry rules:
 1. Add a new heading for the target version before tagging.
 2. Summarize changes under clear sections such as `Added`, `Changed`, `Fixed`, and `Notes`.
 3. Keep the notes user-facing and operationally meaningful.
+4. Keep the `## [Unreleased]` heading in place for ongoing work.
 
 ## CI expectations
 
@@ -32,10 +33,18 @@ The repository keeps separate validation lanes for:
 
 - installed dependency mode
 - repository runtime-compat mode
+- offline smoke validation
+- release-compliance validation
 - desktop web build
 - desktop Tauri cargo check
 
 A release should not be cut while any required lane is red.
+
+Current required release gate behaviors:
+
+- `scripts/release-compliance.sh` must confirm version parity across Python and desktop surfaces.
+- `scripts/release-compliance.sh` must confirm the target release heading exists in `CHANGELOG.md`.
+- The release workflow must stop before artifact publication if compliance fails.
 
 ## Desktop packaging expectation
 
@@ -54,9 +63,10 @@ Primary path:
 
 1. Update versions across Python and desktop surfaces.
 2. Add the new release section to `CHANGELOG.md`.
-3. Ensure CI is green.
-4. Create tag `vX.Y.Z` and push it, or run the manual workflow with `release_version`.
-5. Review generated GitHub release artifacts.
+3. Run `make release-compliance` locally if possible.
+4. Ensure CI is green, including `smoke` and `release-compliance`.
+5. Create tag `vX.Y.Z` and push it, or run the manual workflow with `release_version`.
+6. Review generated GitHub release artifacts.
 
 The release workflow currently produces:
 
@@ -69,6 +79,7 @@ The release workflow currently produces:
 - `CHANGELOG.md` contains the release notes.
 - `README.md`, `docs/STATUS.md`, and `docs/HANDOFF.md` reflect any changed expectations.
 - CI is green on the release commit.
+- `smoke` and `release-compliance` lanes are green.
 - Desktop bundling expectation is still accurate.
 - Tag matches the aligned version.
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PYTHON_BIN="${PYTHON:-python3}"
+VENV_DIR="${VENV_DIR:-.venv}"
+
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  echo "python interpreter not found: $PYTHON_BIN" >&2
+  exit 1
+fi
+
+"$PYTHON_BIN" -m venv "$VENV_DIR"
+"$VENV_DIR/bin/python" -m pip install --upgrade pip
+"$VENV_DIR/bin/pip" install -e .[dev]
+
+if [ ! -f .env ] && [ -f .env.example ]; then
+  cp .env.example .env
+fi
+
+"$VENV_DIR/bin/python" -m superajan12.cli init-db
+
+echo "Bootstrap complete."
+echo "Next steps:"
+echo "  source $VENV_DIR/bin/activate"
+echo "  make check"
+echo "  make smoke"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-all}"
+PYTHON_BIN="${PYTHON:-python3}"
+VENV_DIR="${VENV_DIR:-.venv}"
+VENV_PYTHON="$VENV_DIR/bin/python"
+
+run_full() {
+  if [ ! -x "$VENV_PYTHON" ]; then
+    echo "missing $VENV_PYTHON; run 'make bootstrap' first" >&2
+    exit 1
+  fi
+
+  "$VENV_PYTHON" -m ruff check src tests
+  "$VENV_PYTHON" -m pytest -q -o pythonpath=
+}
+
+run_compat() {
+  PYTHONPATH=src "$PYTHON_BIN" -m pytest -q
+}
+
+case "$MODE" in
+  full)
+    run_full
+    ;;
+  compat)
+    run_compat
+    ;;
+  all)
+    run_full
+    run_compat
+    ;;
+  *)
+    echo "usage: bash scripts/check.sh [full|compat|all]" >&2
+    exit 1
+    ;;
+esac
+
+echo "Validation complete for mode=$MODE"

--- a/scripts/release-compliance.sh
+++ b/scripts/release-compliance.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_VERSION="${TARGET_VERSION:-${1:-}}"
+export TARGET_VERSION
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+root = Path.cwd()
+target_version = os.environ.get("TARGET_VERSION", "").strip()
+
+with (root / "pyproject.toml").open("rb") as handle:
+    pyproject = tomllib.load(handle)
+with (root / "apps/desktop/package.json").open("r", encoding="utf-8") as handle:
+    package_json = json.load(handle)
+with (root / "apps/desktop/src-tauri/tauri.conf.json").open("r", encoding="utf-8") as handle:
+    tauri_conf = json.load(handle)
+with (root / "apps/desktop/src-tauri/Cargo.toml").open("rb") as handle:
+    cargo_toml = tomllib.load(handle)
+
+versions = {
+    "pyproject.toml": pyproject["project"]["version"],
+    "apps/desktop/package.json": package_json["version"],
+    "apps/desktop/src-tauri/tauri.conf.json": tauri_conf["version"],
+    "apps/desktop/src-tauri/Cargo.toml": cargo_toml["package"]["version"],
+}
+
+unique_versions = sorted(set(versions.values()))
+if len(unique_versions) != 1:
+    details = "\n".join(f"- {path}: {version}" for path, version in versions.items())
+    raise SystemExit(f"version mismatch across release surfaces:\n{details}")
+
+aligned_version = unique_versions[0]
+semver_pattern = re.compile(r"^\d+\.\d+\.\d+$")
+if not semver_pattern.match(aligned_version):
+    raise SystemExit(f"aligned version is not strict semver: {aligned_version}")
+
+changelog_text = (root / "CHANGELOG.md").read_text(encoding="utf-8")
+if "## [Unreleased]" not in changelog_text:
+    raise SystemExit("CHANGELOG.md is missing the required '## [Unreleased]' heading")
+
+if target_version:
+    if target_version.startswith("v"):
+        raise SystemExit("TARGET_VERSION must not include the 'v' prefix")
+    if not semver_pattern.match(target_version):
+        raise SystemExit(f"TARGET_VERSION is not strict semver: {target_version}")
+    if target_version != aligned_version:
+        raise SystemExit(
+            f"target version {target_version} does not match aligned repo version {aligned_version}"
+        )
+    release_heading = f"## [{target_version}]"
+    if release_heading not in changelog_text:
+        raise SystemExit(
+            f"CHANGELOG.md is missing the required heading for release version {target_version}"
+        )
+    print(f"release compliance ok for target version {target_version}")
+else:
+    print(f"release surface versions aligned at {aligned_version}")
+    print("CHANGELOG.md contains the required [Unreleased] heading")
+PY

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PYTHON_BIN="${PYTHON:-python3}"
+VENV_DIR="${VENV_DIR:-.venv}"
+
+if [ -x "$VENV_DIR/bin/python" ]; then
+  RUNNER="$VENV_DIR/bin/python"
+else
+  RUNNER="$PYTHON_BIN"
+fi
+
+run_cli() {
+  if [ "$RUNNER" = "$PYTHON_BIN" ]; then
+    PYTHONPATH=src "$RUNNER" -m superajan12.cli "$@"
+  else
+    "$RUNNER" -m superajan12.cli "$@"
+  fi
+}
+
+run_cli init-db
+run_cli report --top 1
+run_cli shadow-report
+run_cli strategy-list --limit 1
+run_cli model-list --limit 1
+run_cli model-history --limit 1
+run_cli model-policy --limit 1
+run_cli operations-report
+
+echo "Offline smoke checks completed."
+echo "For network-backed checks, run: make verify-endpoints && make reference-check"


### PR DESCRIPTION
Replacement for draft PR #29 because the draft-to-ready connector transition is currently failing upstream.

## What changed
- Added a root `Makefile` with stable entrypoints for bootstrap, validation, smoke checks, backend startup, and web startup.
- Added `scripts/bootstrap.sh`, `scripts/check.sh`, and `scripts/smoke.sh` so local setup and repeat validation no longer depend on scattered ad hoc commands.
- Added `CONTRIBUTING.md`, `docs/DEVELOPMENT.md`, and `.editorconfig` to make workflow and formatting expectations explicit.
- Expanded `.gitignore` for local build, coverage, and desktop dependency artifacts.
- Updated `README.md`, `docs/HANDOFF.md`, and `CHANGELOG.md` to point at the new workflow.

## Why
- The repository was usable, but the local setup and validation path was spread across multiple docs and command snippets.
- Re-entry cost was still higher than it should be, especially in constrained environments where the fallback lane matters.
- This patch makes the repo easier to bootstrap, easier to validate repeatedly, and less likely to accumulate local artifact noise.

## Impact
- Day-to-day repo usage becomes more predictable through `make` targets and dedicated helper scripts.
- Contributors now have one documented place to start, one place to validate, and one fallback path when package or toolchain setup is blocked.
- No trading behavior, execution permissions, or secret handling semantics are widened by this change.

## Safety boundary
- Tooling, docs, and repository hygiene only.
- No live order sending.
- No secrets, credentials, signing, or account access.

## Validation
- I verified the new files and README/doc wiring on the branch through the GitHub contents API.
- I could not run the repository locally in this container because direct GitHub clone/network checkout is blocked here.

## Follow-up
- If desired, the next hardening pass can add a single `doctor` command inside the Python CLI so repo validation is available both through `make` and through `superajan12` itself.