### PR TITLE
[codex] Add CI secret scan and tighten workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
@@ -7,7 +10,25 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
+
   python-real-deps:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,11 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   release-compliance:
@@ -108,6 +112,8 @@ jobs:
       - release-compliance
       - build-python
       - build-desktop-web
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,7 @@
+title = "superajan12 gitleaks config"
+
+[allowlist]
+description = "No repository-wide allowlist entries by default"
+paths = []
+regexes = []
+commits = []

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.2
+    hooks:
+      - id: gitleaks
+        args: ["--config=.gitleaks.toml", "--verbose"]

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -58,6 +58,18 @@ make run-backend
 make run-web
 ```
 
+## Local security gate
+
+Install pre-commit once if you want the same secret leak check before commit that CI now runs:
+
+```bash
+pip install pre-commit
+pre-commit install
+pre-commit run --all-files
+```
+
+This uses `.pre-commit-config.yaml` and `.gitleaks.toml` to scan for accidental secret commits before code leaves your machine.
+
 ## When to use each lane
 
 - `make test`: use when the package is installed into `.venv` and you want the real dependency lane.


### PR DESCRIPTION
## What changed
- Added a `secret-scan` CI job using `gitleaks` so pull requests and pushes fail on accidental secret commits.
- Added `.gitleaks.toml` and `.pre-commit-config.yaml` so the same leak check can run locally before commit.
- Tightened workflow permissions and added concurrency controls so CI/release runs use least privilege and cancel stale duplicates.
- Updated `docs/DEVELOPMENT.md` with the local pre-commit secret scan path.

## Why
- Workstream #36 calls for explicit secret-leak blocking in CI and a usable local safety path.
- The repo already had stronger release gates, but it still lacked an early secret scan and clearer workflow permission boundaries.

## Safety boundary
- CI, workflow, and developer-tooling hardening only.
- No runtime trading behavior changes.
- No secret values added.

## Validation
- CI will now run a dedicated secret-scan lane on PRs and pushes.
- Release workflow write permission is limited to the publish job.

## Roadmap link
Advances #36 with a concrete CI secret-leak gate and advances #37 with workflow hardening.