### PR TITLE
[codex] Add dependency vulnerability scan lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,34 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: .gitleaks.toml
 
+  dependency-vuln-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Audit Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev] pip-audit
+          pip-audit
+
+      - name: Audit desktop web dependencies
+        working-directory: apps/desktop
+        run: |
+          npm install
+          npm audit --audit-level=high
+
   python-real-deps:
     runs-on: ubuntu-latest
     steps:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -70,6 +70,20 @@ pre-commit run --all-files
 
 This uses `.pre-commit-config.yaml` and `.gitleaks.toml` to scan for accidental secret commits before code leaves your machine.
 
+## Dependency audit lane
+
+CI now runs a separate dependency vulnerability lane for both Python and desktop web dependencies.
+
+A close local equivalent is:
+
+```bash
+pip install pip-audit
+pip-audit
+cd apps/desktop && npm install && npm audit --audit-level=high
+```
+
+Use this before opening a PR when dependency versions or lockfile behavior change.
+
 ## When to use each lane
 
 - `make test`: use when the package is installed into `.venv` and you want the real dependency lane.


### PR DESCRIPTION
## What changed
- Added a dedicated `dependency-vuln-scan` CI job for both Python and desktop web dependencies.
- The Python side installs `pip-audit` and fails on known vulnerable packages.
- The desktop web side runs `npm audit --audit-level=high` after dependency install.
- Updated `docs/DEVELOPMENT.md` with the nearest local equivalent commands.

## Why
- Workstream #37 still had an explicit supply-chain scanning gap.
- The repository now blocks secret leaks, but dependency-risk drift should also fail early at PR time.

## Safety boundary
- CI and developer-workflow hardening only.
- No runtime trading behavior changes.
- No secrets or permission scope widening.

## Validation
- CI will now run a separate vulnerability lane in parallel with lint, tests, smoke, and release-compliance.

## Roadmap link
Advances #37 with a concrete supply-chain vulnerability scanning lane.