### PR TITLE
[codex] Add security inventory and compliance boundary docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,14 @@ Bu dosyalar `.gitignore` icindedir ve repoya yazilmaz.
 - Web paneldeki scan butonu sadece paper/shadow kayit uretir; canli emir gondermez.
 - Faz 1/Faz 2 public-data katmaninda trading/auth endpointleri kullanilmaz.
 
+Guvenlik ve compliance referanslari:
+
+- `docs/SECRET_INVENTORY.md`
+- `docs/SECRET_ROTATION_RUNBOOK.md`
+- `docs/COMPLIANCE_BOUNDARY.md`
+- `docs/PRODUCTION_CHECKLIST.md`
+- `docs/RUNBOOK.md`
+
 ## Endpoint notlari
 
 - Polymarket Gamma API: aktif marketleri bulmak icin `/markets`.

--- a/docs/COMPLIANCE_BOUNDARY.md
+++ b/docs/COMPLIANCE_BOUNDARY.md
@@ -1,0 +1,75 @@
+# SuperAjan12 Compliance Boundary
+
+This document states what the project is allowed to do now, what remains blocked, and which controls must exist before any live-capable path moves forward.
+
+## Current boundary
+
+SuperAjan12 is currently approved for:
+
+- public market-data collection
+- paper idea generation
+- paper position tracking
+- shadow mark-to-market and scoring
+- operator-facing readiness, safety, and audit surfaces
+- dry-run order preparation only
+
+SuperAjan12 is not currently approved for:
+
+- real order submission
+- custody or fund movement
+- withdrawals or transfers
+- unattended live trading
+- bypassing venue, jurisdiction, or platform restrictions
+
+## Hard rules
+
+- Live trading stays disabled until `docs/PRODUCTION_CHECKLIST.md` is complete.
+- Missing secrets, missing approval, or missing reconciliation must fail closed.
+- No code or workflow may assume geographic/platform eligibility without operator review.
+- Research signals do not override risk or compliance gates.
+- Draft readiness, CI success, or a green dashboard is not the same as compliance approval.
+
+## Required controls before any live-capable path
+
+1. Secret inventory exists and is current.
+2. Rotation runbook exists and is tested operationally.
+3. Manual approval flow is documented and exercised.
+4. Reconciliation is wired to real venue state and fails closed on mismatch.
+5. Audit evidence is retained and reviewable.
+6. Operator runbook covers startup, shutdown, incident, and rollback.
+7. Jurisdiction and platform eligibility are reviewed for the real operator.
+
+## Minimum-permission expectation
+
+Any future venue credential must be restricted to the smallest workable scope. If a provider cannot limit permissions adequately, it should not be used for a live-capable path.
+
+## Operator attestations expected before future live work
+
+An operator should be able to affirm all of the following:
+
+- I know which credentials exist and where they are stored.
+- I know who owns each credential and when it was last rotated.
+- I have reviewed venue/platform eligibility for my jurisdiction.
+- I understand the first-risk cap and rollback plan.
+- I can disable the runtime quickly if a safety or reconciliation incident appears.
+
+## Release boundary
+
+A release artifact may be published for paper/shadow software without implying live-trading approval. Release-readiness and live-readiness are separate gates.
+
+## Incident posture
+
+The following conditions should be treated as compliance-relevant blockers:
+
+- secret leakage or uncertain credential exposure
+- reconciliation mismatch or synthetic reconciliation success
+- missing audit evidence for operator-sensitive actions
+- unexplained approval bypass behavior
+- unknown venue/account permission scope
+
+## Related docs
+
+- `docs/PRODUCTION_CHECKLIST.md`
+- `docs/SECRET_INVENTORY.md`
+- `docs/SECRET_ROTATION_RUNBOOK.md`
+- `docs/RUNBOOK.md`

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -2,6 +2,13 @@
 
 This checklist must be completed before any real-money adapter is added.
 
+Supporting policy docs:
+
+- `docs/SECRET_INVENTORY.md`
+- `docs/SECRET_ROTATION_RUNBOOK.md`
+- `docs/COMPLIANCE_BOUNDARY.md`
+- `docs/RUNBOOK.md`
+
 ## 1. Runtime verification
 
 - [ ] `superajan12 verify-endpoints` passes consistently.
@@ -42,9 +49,10 @@ This checklist must be completed before any real-money adapter is added.
 
 - [ ] No secrets in git.
 - [ ] Secrets are provided by environment or external secret manager.
+- [ ] Secret inventory exists and owners are recorded.
 - [ ] API keys have minimum permissions.
 - [ ] Withdrawal permissions are disabled.
-- [ ] Key rotation plan exists.
+- [ ] Key rotation plan exists and is testable.
 
 ## 6. Legal and platform eligibility
 
@@ -52,6 +60,7 @@ This checklist must be completed before any real-money adapter is added.
 - [ ] No geographic restriction is bypassed.
 - [ ] Terms of service are reviewed.
 - [ ] Tax/reporting obligations are understood.
+- [ ] Compliance boundary is reviewed by the operator.
 
 ## 7. Live adapter gate
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -132,6 +132,7 @@ If any of the following happen, stop scanning and inspect logs:
 - SQLite write failures occur.
 - Audit log is not written.
 - Reconciliation mismatch appears.
+- Secret exposure is suspected.
 
 Immediate actions:
 
@@ -141,6 +142,17 @@ Immediate actions:
 4. Check `.env` settings.
 5. Run tests.
 6. Resume only after root cause is understood.
+
+For secret-related incidents, follow `docs/SECRET_ROTATION_RUNBOOK.md` before resuming any affected provider path.
+
+## Security and compliance references
+
+Read these together before any future live-capable work:
+
+- `docs/SECRET_INVENTORY.md`
+- `docs/SECRET_ROTATION_RUNBOOK.md`
+- `docs/COMPLIANCE_BOUNDARY.md`
+- `docs/PRODUCTION_CHECKLIST.md`
 
 ## Logs and data
 

--- a/docs/SECRET_INVENTORY.md
+++ b/docs/SECRET_INVENTORY.md
@@ -1,0 +1,81 @@
+# SuperAjan12 Secret Inventory
+
+This document tracks secret classes, their intended scope, minimum permission boundary, storage expectations, and rotation owner. It never stores secret values.
+
+## Rules
+
+- No secret values belong in git, screenshots, issue comments, PR reviews, or audit payloads.
+- Every secret must have a single named owner.
+- Every secret must have the minimum permission scope needed for its runtime path.
+- Live-capable secrets stay out of local `.env` files unless the operator intentionally accepts the local-risk tradeoff.
+- Withdrawal, transfer, custody, or portfolio-wide write scopes are out of bounds for this project.
+
+## Secret classes
+
+| Secret | Purpose | Required for current paper/shadow mode | Future live relevance | Minimum scope | Storage expectation | Owner |
+| --- | --- | --- | --- | --- | --- | --- |
+| `SUPERAJAN12_LIVE_API_KEY` | Exchange or venue API identity for future live-capable preview paths | No | Yes | Trade-preview or restricted execution only; never withdrawal | External secret manager preferred; environment injection allowed for isolated local testing | Operator |
+| `SUPERAJAN12_LIVE_API_SECRET` | Paired signing/auth secret for future live-capable preview paths | No | Yes | Same scope as paired API key; never withdrawal | External secret manager preferred; environment injection allowed for isolated local testing | Operator |
+| `DUNE_API_KEY` | Wallet and on-chain research provider access | No | Optional research only | Read-only analytics | Environment or external secret manager | Research owner |
+| `NANSEN_API_KEY` | Wallet and smart-money research provider access | No | Optional research only | Read-only analytics | Environment or external secret manager | Research owner |
+| `GLASSNODE_API_KEY` | On-chain metrics provider access | No | Optional research only | Read-only analytics | Environment or external secret manager | Research owner |
+| `X_BEARER_TOKEN` | Social/news enrichment source | No | Optional research only | Read-only API access | Environment or external secret manager | Research owner |
+| `REDDIT_CLIENT_ID` / `REDDIT_CLIENT_SECRET` | Reddit-based research ingestion | No | Optional research only | Read-only API access | Environment or external secret manager | Research owner |
+| `COINGECKO_API_KEY` | CoinGecko premium/news endpoints if enabled | No | Optional reference/research only | Read-only market/news access | Environment or external secret manager | Research owner |
+
+## Current enforcement boundary
+
+Current paper/shadow operation does not require any live-trading secret. The backend already reports missing live execution secrets as a blocking readiness condition.
+
+## Rotation metadata to track
+
+Every secret should have these fields recorded outside git:
+
+- secret name
+- owner
+- provider or venue
+- scope granted
+- creation time
+- last rotated time
+- next rotation due time
+- last validation time
+- emergency disable path
+
+## Scope policy
+
+Allowed future scope:
+
+- read-only market-data access
+- preview-only or tightly scoped trade access when live gates are explicitly unlocked later
+
+Forbidden scope:
+
+- withdrawals
+- transfers
+- account recovery actions
+- sub-account creation
+- wildcard organization-wide admin access
+
+## Local development guidance
+
+- Prefer `.env` only for public-data or read-only research credentials.
+- Treat any live-capable credential as production-sensitive even during local testing.
+- Remove local credentials immediately after troubleshooting.
+- Re-run secret scanning before every push.
+
+## Audit expectation
+
+Any future live-capable secret onboarding should leave evidence in operator documentation:
+
+- who created it
+- what scope was granted
+- where it is stored
+- when it was last rotated
+- which runbook was used
+
+## Related docs
+
+- `docs/SECRET_ROTATION_RUNBOOK.md`
+- `docs/COMPLIANCE_BOUNDARY.md`
+- `docs/PRODUCTION_CHECKLIST.md`
+- `docs/RUNBOOK.md`

--- a/docs/SECRET_ROTATION_RUNBOOK.md
+++ b/docs/SECRET_ROTATION_RUNBOOK.md
@@ -1,0 +1,94 @@
+# SuperAjan12 Secret Rotation Runbook
+
+This runbook defines how to rotate sensitive credentials without widening the live-execution boundary.
+
+## When rotation is required
+
+Rotate immediately when any of these happens:
+
+- suspected leak or accidental exposure
+- operator laptop compromise or credential file loss
+- team/owner change
+- provider-side security event
+- permission scope drift
+- scheduled rotation due date arrives
+
+## Preconditions
+
+Before rotating a secret:
+
+1. Confirm the secret class in `docs/SECRET_INVENTORY.md`.
+2. Verify the minimum scope you actually need.
+3. Identify every runtime surface that reads the secret.
+4. Confirm whether the system is currently running.
+5. Prepare a rollback or disable path.
+
+## Rotation procedure
+
+1. Create a replacement credential with the minimum allowed scope.
+2. Record rotation metadata outside git: owner, scope, created-at, rotation reason, next due date.
+3. Update the secret in the external secret manager or environment injection path.
+4. Restart or reload only the process that consumes the secret.
+5. Run the narrowest validation command that proves the secret still works.
+6. Revoke the old credential after validation succeeds.
+7. Record completion time and operator name.
+
+## Validation examples
+
+Read-only research provider rotation:
+
+```bash
+superajan12-web
+```
+
+Then confirm the relevant provider still shows as configured and healthy in the operator surface.
+
+Future live-capable credential rotation:
+
+```bash
+superajan12 execution-check --mode live --secrets-ready
+```
+
+This must stay in preview/dry-run territory only. It is a readiness check, not permission to send orders.
+
+## Emergency leak response
+
+If a secret may have leaked:
+
+1. Disable or revoke the credential at the provider immediately.
+2. Stop the affected runtime path.
+3. Preserve local audit evidence and CI logs.
+4. Remove the secret from every local file, shell history, and temporary note.
+5. Create a fresh credential with reduced scope if possible.
+6. Run secret scanning before any new push or release.
+7. Document the incident and remediation steps.
+
+## Scope downgrade guidance
+
+When recreating a credential, prefer stricter scope than before if the system does not actively need the old scope. Rotation is a good moment to remove unnecessary permissions.
+
+## What must never happen
+
+- Never paste a secret into git-tracked files.
+- Never rotate by editing docs with secret values.
+- Never keep both old and new live-capable credentials active longer than necessary.
+- Never grant withdrawal or transfer rights for convenience.
+
+## Evidence to retain outside git
+
+Keep these facts in the operator record:
+
+- secret name
+- provider
+- owner
+- old scope and new scope
+- rotation reason
+- validation method
+- completion time
+- revocation confirmation for the old credential
+
+## Related docs
+
+- `docs/SECRET_INVENTORY.md`
+- `docs/COMPLIANCE_BOUNDARY.md`
+- `docs/RUNBOOK.md`


### PR DESCRIPTION
Replacement for draft PR #47 because the draft-to-ready connector transition is currently failing upstream.

## What changed
- Added `docs/SECRET_INVENTORY.md` to define secret classes, owners, minimum scopes, and storage expectations without storing any secret values.
- Added `docs/SECRET_ROTATION_RUNBOOK.md` with a concrete rotation and leak-response procedure.
- Added `docs/COMPLIANCE_BOUNDARY.md` to separate paper/shadow approval from any future live-capable path.
- Wired the new docs into `README.md`, `docs/RUNBOOK.md`, and `docs/PRODUCTION_CHECKLIST.md` so the operator path points at the new policy surface.

## Why
- Workstream #36 explicitly calls for secret inventory, rotation policy, and compliance boundary docs before any live-capable path exists.
- The repo already had strong safety language, but these operational policies were still implicit and scattered.
- This patch makes the boundaries auditable and easier to follow without changing runtime trading behavior.

## Safety boundary
- Documentation and operator-policy hardening only.
- No live order sending.
- No secrets, credentials, signing keys, or account access added.

## Validation
- Verified the new docs are linked from the main operator/readiness surfaces.
- No runtime code paths were changed.

## Roadmap link
Advances #36 by adding the first required documentation bundle for secret handling and compliance boundaries.