### PR TITLE
[codex] Emit reconciliation blocking incident and veto evidence

### DIFF
--- a/src/superajan12/backend_api.py
+++ b/src/superajan12/backend_api.py
@@ -386,6 +386,22 @@ def create_backend_app() -> FastAPI:
         secrets_ready = all(secret.present for secret in secret_refs)
         local_open_positions = len(store.list_open_positions())
         reconciliation = ReconciliationAgent().blocking_placeholder()
+        reconciliation_vetoes = [reconciliation.code, *reconciliation.reasons]
+        latest_reconciliation_veto = store.latest_execution_veto("reconciliation")
+        should_record_reconciliation_block = not reconciliation.ok and (
+            latest_reconciliation_veto is None
+            or list(latest_reconciliation_veto.get("vetoes") or []) != reconciliation_vetoes
+        )
+        if should_record_reconciliation_block:
+            store.record_execution_veto(scope="reconciliation", vetoes=reconciliation_vetoes)
+            event_bus.publish(
+                "reconciliation.blocking",
+                {
+                    "code": reconciliation.code,
+                    "reasons": list(reconciliation.reasons),
+                    "local_open_positions": local_open_positions,
+                },
+            )
         readiness = _build_micro_live_readiness(
             store=store,
             strategy_payload=strategy_payload,
@@ -423,6 +439,7 @@ def create_backend_app() -> FastAPI:
             },
             "reconciliation": {
                 "ok": reconciliation.ok,
+                "code": reconciliation.code,
                 "reasons": list(reconciliation.reasons),
                 "local_open_positions": local_open_positions,
             },
@@ -542,6 +559,7 @@ def create_backend_app() -> FastAPI:
         rows = store.list_open_positions()
         payload = {
             "positions": rows,
+            "count": len(rows),
             "shadow": store.shadow_summary(),
         }
         event_bus.publish("positions.snapshot", {"count": len(rows)})

--- a/src/superajan12/reconciliation.py
+++ b/src/superajan12/reconciliation.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class ReconciliationResult:
     ok: bool
+    code: str
     reasons: tuple[str, ...]
 
 
@@ -20,15 +21,17 @@ class ReconciliationAgent:
         if local_open_positions != external_open_positions:
             return ReconciliationResult(
                 ok=False,
+                code="RECON_POSITION_MISMATCH",
                 reasons=(
                     f"position count mismatch: local={local_open_positions}, external={external_open_positions}",
                 ),
             )
-        return ReconciliationResult(ok=True, reasons=("position counts match",))
+        return ReconciliationResult(ok=True, code="RECON_OK", reasons=("position counts match",))
 
     def blocking_placeholder(self) -> ReconciliationResult:
         return ReconciliationResult(
             ok=False,
+            code="RECON_NOT_WIRED",
             reasons=(
                 "live reconciliation is not wired to a real venue yet",
                 "blocking live readiness until external positions and orders are checked",

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -103,6 +103,7 @@ def test_backend_command_center_endpoints_have_expected_shapes() -> None:
     assert "guard" in execution_payload
     assert execution_payload["live_trading"] == "disabled"
     assert execution_payload["reconciliation"]["ok"] is False
+    assert execution_payload["reconciliation"]["code"] == "RECON_NOT_WIRED"
     assert any("not wired" in reason for reason in execution_payload["reconciliation"]["reasons"])
 
     assert system_health.status_code == 200
@@ -230,4 +231,46 @@ def test_execution_operator_acknowledgement_endpoint_persists(tmp_path, monkeypa
     assert operator_ack["acknowledged"] is True
     assert operator_ack["acknowledged_by"] == "test-operator"
     assert operator_ack["note"] == "manual review completed"
+    get_settings.cache_clear()
+
+
+def test_execution_status_emits_deduplicated_reconciliation_blocking_event(tmp_path, monkeypatch) -> None:
+    sqlite_path = tmp_path / "reconciliation.sqlite3"
+    audit_path = tmp_path / "audit.jsonl"
+    monkeypatch.setenv("SQLITE_PATH", str(sqlite_path))
+    monkeypatch.setenv("AUDIT_LOG_PATH", str(audit_path))
+    get_settings.cache_clear()
+
+    client = TestClient(app)
+    baseline_events = client.get("/events").json()["events"]
+    baseline_count = sum(1 for event in baseline_events if event["type"] == "reconciliation.blocking")
+
+    first = client.get("/execution/status")
+    second = client.get("/execution/status")
+    ack = client.post(
+        "/execution/operator-acknowledgement",
+        json={
+            "acknowledged": True,
+            "acknowledged_by": "dedupe-tester",
+            "note": "should not duplicate reconciliation block",
+        },
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert ack.status_code == 200
+    assert first.json()["reconciliation"]["code"] == "RECON_NOT_WIRED"
+
+    events = client.get("/events").json()["events"]
+    blocking_events = [event for event in events if event["type"] == "reconciliation.blocking"]
+    assert len(blocking_events) == baseline_count + 1
+    latest_payload = blocking_events[-1]["payload"]
+    assert latest_payload["code"] == "RECON_NOT_WIRED"
+    assert latest_payload["local_open_positions"] == 0
+
+    store = SQLiteStore(sqlite_path)
+    veto = store.latest_execution_veto("reconciliation")
+    assert veto is not None
+    assert veto["scope"] == "reconciliation"
+    assert veto["vetoes"][0] == "RECON_NOT_WIRED"
     get_settings.cache_clear()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -148,3 +148,26 @@ def test_auto_shadow_mark_uses_latest_market_scores(tmp_path) -> None:
     assert rows[0]["status"] == "marked"
     assert rows[0]["latest_price"] == 0.6
     assert rows[0]["category"] == "crypto"
+
+
+def test_execution_veto_persistence_round_trip(tmp_path) -> None:
+    store = SQLiteStore(tmp_path / "superajan12.sqlite3")
+
+    veto_id = store.record_execution_veto(
+        scope="reconciliation",
+        vetoes=[
+            "RECON_NOT_WIRED",
+            "live reconciliation is not wired to a real venue yet",
+        ],
+    )
+
+    veto = store.latest_execution_veto("reconciliation")
+
+    assert veto_id == 1
+    assert veto is not None
+    assert veto["scope"] == "reconciliation"
+    assert veto["vetoes"] == [
+        "RECON_NOT_WIRED",
+        "live reconciliation is not wired to a real venue yet",
+    ]
+    assert veto["created_at"]


### PR DESCRIPTION
## What changed
- Added deterministic reconciliation result codes: `RECON_OK`, `RECON_POSITION_MISMATCH`, and `RECON_NOT_WIRED`.
- Updated `/execution/status` so reconciliation blocking state now includes a machine-readable `code`.
- When reconciliation is blocking, the backend now emits a `reconciliation.blocking` event and persists reconciliation veto evidence through the existing execution veto store.
- Added deduplication so repeated polling of the same blocking condition does not spam events or veto rows.
- Expanded backend and storage tests to cover the new code path and veto persistence.

## Why
- Issue #49 pulls a small but safety-relevant follow-up out of the readiness program.
- The repo already blocks live readiness when reconciliation is not wired, but that state was still mostly plain text.
- This patch makes the block observable and auditable without widening any runtime permissions.

## Safety boundary
- No live order sending.
- No secret or account scope changes.
- No schema migration required.

## Validation
- Added regression coverage in `tests/test_backend_api.py` and `tests/test_storage.py`.
- This environment could not run the repo test suite locally because direct checkout/runtime execution is restricted here, so validation is code-and-test-path based in GitHub content space.

## Roadmap link
Advances #49 and supports the broader issue #32 safety/readiness track.