### PR TITLE
[codex] Harden repo workflow, replay gate, and web runtime startup

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+## Summary
+
+- What changed:
+- Why it changed:
+
+## Scope
+
+- Issue link:
+- In scope:
+- Out of scope:
+
+## Safety boundary
+
+- Runtime or execution impact:
+- Secret, credential, or permission impact:
+- Live-trading impact:
+
+## Validation
+
+- Commands run:
+- Checks not run and why:
+
+## Rollback
+
+- Revert plan:
+- Risk if reverted:
+
+## Docs impact
+
+- [ ] `README.md`
+- [ ] `docs/DEVELOPMENT.md`
+- [ ] `docs/PRODUCTION_CHECKLIST.md`
+- [ ] `docs/ACTIVE_EXECUTION_QUEUE.md`
+- [ ] No doc updates needed
+
+## Merge aftercare
+
+- [ ] Queue / blocker / next-step state updated
+- [ ] Follow-up issue created when this PR is intentionally partial

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,25 @@ jobs:
       - name: Offline smoke validation
         run: make smoke
 
+  replay-market-state:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+
+      - name: Replay and market-state regression lane
+        run: pytest -q tests/test_orderbook_replay.py tests/test_market_state.py
+
   release-compliance:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,26 @@ Keep SuperAjan12 easy to run, easy to validate, and hard to accidentally weaken.
 - Prefer focused pull requests with a clear validation path.
 - Update docs when behavior, commands, or operational expectations change.
 
+## Issue-driven workflow
+
+- Start each meaningful change from an issue or an explicit sub-task linked to an issue.
+- Keep every branch scoped to one issue or one clearly named wave of an issue.
+- Close issues only when acceptance criteria are met, not when partial progress exists.
+- Use issue bodies to capture `Problem`, `Scope`, `Acceptance Criteria`, `Out of Scope`, and `Risk`.
+
+## Branch naming
+
+Use these branch formats:
+
+- `codex/<issue-no>-<short-kebab>` for normal engineering work
+- `hotfix/<issue-no>-<short-kebab>` for urgent production-facing fixes
+
+Examples:
+
+- `codex/31-replay-market-state-gate`
+- `codex/8-runtime-startup-lifecycle`
+- `hotfix/54-release-icon-regression`
+
 ## Local setup
 
 Recommended path:
@@ -39,6 +59,7 @@ make lint
 make test
 make test-compat
 make smoke
+pytest -q tests/test_orderbook_replay.py tests/test_market_state.py
 ```
 
 Network-backed checks are intentionally separate:
@@ -58,6 +79,7 @@ When you change developer workflow, release flow, or operator expectations, revi
 - `docs/HANDOFF.md`
 - `docs/RUNBOOK.md`
 - `docs/RELEASE.md`
+- `docs/ACTIVE_EXECUTION_QUEUE.md`
 - `CHANGELOG.md`
 
 ## Pull request expectations
@@ -68,7 +90,7 @@ A good PR should state:
 2. Why it changed.
 3. Safety boundary, especially if runtime or execution code is touched.
 4. Validation commands used.
-5. Follow-up work left visible.
+5. Rollback notes or follow-up work left visible.
 
 ## Preferred change shape
 
@@ -76,3 +98,5 @@ A good PR should state:
 - Reuse existing repo patterns before inventing new abstractions.
 - Add tests when behavior changes.
 - If full runtime dependencies are unavailable, keep the runtime-compat lane green.
+- Prefer one behavior change per PR plus the matching test and doc updates.
+- Keep merge-aftercare explicit: update `docs/ACTIVE_EXECUTION_QUEUE.md` when the current blocker or next technical move changes.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -42,6 +42,7 @@ make test
 make test-compat
 make check
 make smoke
+pytest -q tests/test_orderbook_replay.py tests/test_market_state.py
 ```
 
 ### Network-backed validation
@@ -90,6 +91,7 @@ Use this before opening a PR when dependency versions or lockfile behavior chang
 - `make test-compat`: use when you need to prove the repository's fallback runtime still works.
 - `make check`: use before PRs or when touching shared code paths.
 - `make smoke`: use for quick confidence that the local CLI/reporting surfaces still start and query storage.
+- `pytest -q tests/test_orderbook_replay.py tests/test_market_state.py`: use when touching replay, orderbook, or market-state logic so the dedicated CI lane does not surprise you.
 
 ## Working agreements for future changes
 

--- a/docs/PRODUCTION_CHECKLIST.md
+++ b/docs/PRODUCTION_CHECKLIST.md
@@ -18,6 +18,7 @@ Supporting policy docs:
 - [ ] JSONL audit log is written.
 - [ ] CI tests pass.
 - [ ] Lint passes.
+- [ ] Replay and market-state regression lane passes.
 
 ## 2. Data quality
 
@@ -27,6 +28,7 @@ Supporting policy docs:
 - [ ] Rejected/watch/approved distribution is understood.
 - [ ] No unexplained orderbook fallback spike.
 - [ ] Reference price deviations are monitored.
+- [ ] Dedicated replay and market-state CI gate stays green after orderbook changes.
 
 ## 3. Strategy validation
 

--- a/src/superajan12/runtime.py
+++ b/src/superajan12/runtime.py
@@ -13,12 +13,28 @@ from superajan12.connectors.polymarket import PolymarketClient
 from superajan12.models import ScanResult
 from superajan12.storage import SQLiteStore
 
+_RUNTIME_BOOTSTRAPPED = False
+
 
 def ensure_runtime_paths(settings: Settings | None = None) -> Settings:
     settings = settings or get_settings()
     SQLiteStore(settings.sqlite_path)
     settings.audit_log_path.parent.mkdir(parents=True, exist_ok=True)
     return settings
+
+
+def bootstrap_runtime(settings: Settings | None = None) -> Settings:
+    global _RUNTIME_BOOTSTRAPPED
+    resolved = ensure_runtime_paths(settings)
+    _RUNTIME_BOOTSTRAPPED = True
+    return resolved
+
+
+def runtime_settings(settings: Settings | None = None) -> Settings:
+    resolved = settings or get_settings()
+    if not _RUNTIME_BOOTSTRAPPED:
+        return bootstrap_runtime(resolved)
+    return resolved
 
 
 def build_polymarket_client(settings: Settings | None = None) -> PolymarketClient:

--- a/src/superajan12/web.py
+++ b/src/superajan12/web.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from typing import Any
 
 import uvicorn
@@ -11,15 +12,23 @@ from superajan12.config import get_settings
 from superajan12.endpoint_check import verify_polymarket_public_endpoints
 from superajan12.reporting import Reporter
 from superajan12.runtime import (
+    bootstrap_runtime,
     build_polymarket_client,
     build_risk_engine,
     build_scan_response,
-    ensure_runtime_paths,
     persist_scan_result,
+    runtime_settings,
 )
 from superajan12.storage import SQLiteStore
 
-app = FastAPI(title="SuperAjan12", version="0.1.0")
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    app.state.runtime_settings = bootstrap_runtime(get_settings())
+    yield
+
+
+app = FastAPI(title="SuperAjan12", version="0.1.0", lifespan=lifespan)
 
 
 INDEX_HTML = """
@@ -223,7 +232,7 @@ def index() -> str:
 
 @app.get("/api/dashboard")
 def dashboard(top: int = Query(default=20, ge=1, le=100)) -> dict[str, Any]:
-    settings = ensure_runtime_paths()
+    settings = runtime_settings()
     store = SQLiteStore(settings.sqlite_path)
     reporter = Reporter(settings.sqlite_path)
     return {
@@ -238,7 +247,7 @@ def dashboard(top: int = Query(default=20, ge=1, le=100)) -> dict[str, Any]:
 
 @app.post("/api/scan")
 async def scan(limit: int = Query(default=25, ge=1, le=100)) -> dict[str, Any]:
-    settings = ensure_runtime_paths()
+    settings = runtime_settings()
     scanner = MarketScannerAgent(
         polymarket=build_polymarket_client(settings),
         risk_engine=build_risk_engine(settings),
@@ -255,7 +264,6 @@ async def verify_endpoints() -> dict[str, Any]:
 
 
 def main() -> None:
-    ensure_runtime_paths(get_settings())
     uvicorn.run("superajan12.web:app", host="127.0.0.1", port=8000, reload=False)
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,5 +1,6 @@
 from fastapi.testclient import TestClient
 
+import superajan12.web as web_module
 from superajan12.web import app
 
 
@@ -24,3 +25,19 @@ def test_dashboard_api_returns_expected_shape() -> None:
     assert "top_markets" in payload
     assert "shadow" in payload
     assert payload["live_trading"] == "disabled"
+
+
+def test_web_runtime_bootstraps_once_on_startup(monkeypatch) -> None:
+    calls: list[int] = []
+
+    def fake_bootstrap_runtime(settings):
+        calls.append(1)
+        return settings
+
+    monkeypatch.setattr(web_module, "bootstrap_runtime", fake_bootstrap_runtime)
+
+    with TestClient(web_module.app) as client:
+        assert client.get("/").status_code == 200
+        assert client.get("/api/dashboard").status_code == 200
+
+    assert calls == [1]


### PR DESCRIPTION
## Summary
- add a dedicated replay and market-state CI lane
- document the new validation lane in development and production-readiness docs
- tighten repo workflow conventions with branch naming and a PR template
- move the web app runtime bootstrap into FastAPI lifespan and add startup coverage
- add shared runtime bootstrap helpers for app startup ownership

## Why
- the repo still needed a clearer connector-first workflow for small, auditable GitHub-native changes
- replay and market-state logic needed its own CI gate instead of hiding inside the broader Python lane
- the web surface still initialized runtime paths from request handlers instead of app startup
- PR hygiene and branch conventions were still mostly implicit

## Validation
- local syntax validation completed for the edited Python files with `python -m py_compile`
- direct runtime test execution is still constrained in this environment because the repo is not mounted as a normal checkout with its full dependency graph
- GitHub compare confirms this branch changes only the intended workflow, docs, runtime helper, web startup, and test files

## Risk
- low to medium
- CI and docs changes affect merge discipline rather than trading behavior
- web runtime startup change is behavior-preserving but moves initialization timing earlier in app lifecycle

## Follow-up
- next wave should move the backend app to the same startup-lifecycle model
- next wave should land persisted execution intents and idempotent prepare endpoints for the guarded execution path
- branch protection should treat `replay-market-state` as a required check once this lane is green
