### PR TITLE
[codex] Add body alias binding to FastAPI and Pydantic shims

### DIFF
--- a/src/fastapi/__init__.py
+++ b/src/fastapi/__init__.py
@@ -1,3 +1,3 @@
-from .app import Cookie, FastAPI, Header, HTTPException, Query, WebSocket, WebSocketDisconnect
+from .app import Body, Cookie, FastAPI, Header, HTTPException, Query, WebSocket, WebSocketDisconnect
 
-__all__ = ["Cookie", "FastAPI", "Header", "HTTPException", "Query", "WebSocket", "WebSocketDisconnect"]
+__all__ = ["Body", "Cookie", "FastAPI", "Header", "HTTPException", "Query", "WebSocket", "WebSocketDisconnect"]

--- a/src/fastapi/app.py
+++ b/src/fastapi/app.py
@@ -37,6 +37,10 @@ def Cookie(default: Any = ..., *, alias: str | None = None) -> ParamValue:
     return ParamValue(source="cookie", default=default, alias=alias)
 
 
+def Body(default: Any = ..., *, alias: str | None = None, embed: bool = False) -> ParamValue:
+    return ParamValue(source="body", default=default, alias=alias)
+
+
 @dataclass
 class HTTPException(Exception):
     status_code: int

--- a/src/fastapi/app.py
+++ b/src/fastapi/app.py
@@ -13,6 +13,7 @@ class ParamValue:
     ge: Any = None
     le: Any = None
     convert_underscores: bool = False
+    embed: bool = False
 
 
 def Query(default: Any = ..., *, alias: str | None = None, ge: Any = None, le: Any = None) -> ParamValue:
@@ -38,7 +39,7 @@ def Cookie(default: Any = ..., *, alias: str | None = None) -> ParamValue:
 
 
 def Body(default: Any = ..., *, alias: str | None = None, embed: bool = False) -> ParamValue:
-    return ParamValue(source="body", default=default, alias=alias)
+    return ParamValue(source="body", default=default, alias=alias, embed=embed)
 
 
 @dataclass

--- a/src/fastapi/testclient.py
+++ b/src/fastapi/testclient.py
@@ -11,7 +11,7 @@ from urllib.parse import parse_qs, urlsplit
 
 from pydantic import BaseModel
 
-from .app import Cookie, FastAPI, HTTPException, Header, ParamValue, Query, WebSocket, WebSocketDisconnect
+from .app import Body, Cookie, FastAPI, HTTPException, Header, ParamValue, Query, WebSocket, WebSocketDisconnect
 from .responses import HTMLResponse
 
 _QUEUE_SENTINEL = object()
@@ -269,11 +269,14 @@ def _build_kwargs(
             continue
 
         if json_body is not None:
-            if inspect.isclass(annotation) and issubclass(annotation, BaseModel):
-                kwargs[name] = annotation(**json_body)
-                continue
-            if name in json_body:
-                kwargs[name] = _coerce_value(json_body[name], annotation)
+            body_found, body_value = _resolve_body_value(
+                name=name,
+                annotation=annotation,
+                default=default,
+                json_body=json_body,
+            )
+            if body_found:
+                kwargs[name] = body_value
                 continue
 
         if isinstance(default, ParamValue):
@@ -289,6 +292,8 @@ def _build_kwargs(
 
 def _resolve_request_value(*, name: str, annotation: Any, default: Any, inputs: _RequestInputs) -> tuple[bool, Any]:
     if isinstance(default, ParamValue):
+        if default.source == "body":
+            return False, None
         source_values = {
             "query": inputs.query_params,
             "header": inputs.headers,
@@ -302,6 +307,39 @@ def _resolve_request_value(*, name: str, annotation: Any, default: Any, inputs: 
     if name in inputs.query_params:
         return True, _coerce_value(inputs.query_params[name], annotation)
     return False, None
+
+
+def _resolve_body_value(*, name: str, annotation: Any, default: Any, json_body: dict[str, Any]) -> tuple[bool, Any]:
+    if isinstance(default, ParamValue) and default.source == "body":
+        for candidate in _body_candidates(name=name, marker=default):
+            if candidate in json_body:
+                return True, _coerce_value(json_body[candidate], annotation)
+        return False, None
+
+    model_type = _body_model_type(annotation)
+    if model_type is not None:
+        return True, model_type(**json_body)
+    if name in json_body:
+        return True, _coerce_value(json_body[name], annotation)
+    return False, None
+
+
+def _body_candidates(*, name: str, marker: ParamValue) -> list[str]:
+    return [item for item in (marker.alias, name) if item]
+
+
+def _body_model_type(annotation: Any) -> type[BaseModel] | None:
+    if inspect.isclass(annotation) and issubclass(annotation, BaseModel):
+        return annotation
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+    if origin is not None and args:
+        for arg in args:
+            if arg is type(None):
+                continue
+            if inspect.isclass(arg) and issubclass(arg, BaseModel):
+                return arg
+    return None
 
 
 def _lookup_candidates(*, name: str, marker: ParamValue) -> list[str]:

--- a/src/fastapi/testclient.py
+++ b/src/fastapi/testclient.py
@@ -312,8 +312,16 @@ def _resolve_request_value(*, name: str, annotation: Any, default: Any, inputs: 
 def _resolve_body_value(*, name: str, annotation: Any, default: Any, json_body: dict[str, Any]) -> tuple[bool, Any]:
     if isinstance(default, ParamValue) and default.source == "body":
         for candidate in _body_candidates(name=name, marker=default):
-            if candidate in json_body:
-                return True, _coerce_value(json_body[candidate], annotation)
+            if candidate not in json_body:
+                continue
+            if default.embed:
+                return True, _coerce_embedded_body_value(json_body[candidate], annotation)
+            return True, _coerce_value(json_body[candidate], annotation)
+        if default.embed:
+            return False, None
+        model_type = _body_model_type(annotation)
+        if model_type is not None:
+            return True, model_type(**json_body)
         return False, None
 
     model_type = _body_model_type(annotation)
@@ -326,6 +334,16 @@ def _resolve_body_value(*, name: str, annotation: Any, default: Any, json_body: 
 
 def _body_candidates(*, name: str, marker: ParamValue) -> list[str]:
     return [item for item in (marker.alias, name) if item]
+
+
+def _coerce_embedded_body_value(value: Any, annotation: Any) -> Any:
+    model_type = _body_model_type(annotation)
+    if model_type is not None:
+        if isinstance(value, model_type):
+            return value
+        if isinstance(value, dict):
+            return model_type(**value)
+    return _coerce_value(value, annotation)
 
 
 def _body_model_type(annotation: Any) -> type[BaseModel] | None:

--- a/src/pydantic.py
+++ b/src/pydantic.py
@@ -44,6 +44,7 @@ def Field(
 
 class BaseModel:
     model_fields: dict[str, _FieldInfo] = {}
+    model_config: dict[str, Any] = {"populate_by_name": True}
 
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
@@ -55,9 +56,17 @@ class BaseModel:
         fields: dict[str, _FieldInfo] = {}
         for base in reversed(cls.__mro__[1:]):
             fields.update(getattr(base, "model_fields", {}))
+        config: dict[str, Any] = {"populate_by_name": True}
+        for base in reversed(cls.__mro__[1:]):
+            base_config = getattr(base, "model_config", None)
+            if isinstance(base_config, dict):
+                config.update(base_config)
+        raw_config = getattr(cls, "model_config", None)
+        if isinstance(raw_config, dict):
+            config.update(raw_config)
 
         for name in annotations:
-            if name == "model_fields":
+            if name in {"model_fields", "model_config"}:
                 continue
             raw_default = getattr(cls, name, ...)
             if isinstance(raw_default, _FieldInfo):
@@ -66,12 +75,18 @@ class BaseModel:
                 info = _FieldInfo(default=raw_default)
             fields[name] = info
         cls.model_fields = fields
+        cls.model_config = config
 
     def __init__(self, **data: Any) -> None:
         annotations = self._model_annotations()
+        populate_by_name = bool(self.model_config.get("populate_by_name", True))
         for name, info in self.model_fields.items():
             value = ...
-            for candidate in (name, info.alias, info.validation_alias):
+            candidates = []
+            if populate_by_name:
+                candidates.append(name)
+            candidates.extend([info.alias, info.validation_alias])
+            for candidate in candidates:
                 if candidate and candidate in data:
                     value = data[candidate]
                     break
@@ -89,10 +104,10 @@ class BaseModel:
             annotations.update(getattr(base, "__annotations__", {}))
         return annotations
 
-    def model_dump(self, mode: str | None = None) -> dict[str, Any]:
+    def model_dump(self, mode: str | None = None, by_alias: bool = False) -> dict[str, Any]:
         return {
-            name: _serialize_value(getattr(self, name), mode=mode)
-            for name in self.model_fields
+            (info.alias if by_alias and info.alias else name): _serialize_value(getattr(self, name), mode=mode)
+            for name, info in self.model_fields.items()
         }
 
 

--- a/src/pydantic.py
+++ b/src/pydantic.py
@@ -15,6 +15,7 @@ AnyHttpUrl = str
 class _FieldInfo:
     default: Any = ...
     default_factory: Any = None
+    alias: str | None = None
     validation_alias: str | None = None
 
     def get_default(self) -> Any:
@@ -29,12 +30,14 @@ def Field(
     default: Any = ...,
     *,
     default_factory: Any = None,
+    alias: str | None = None,
     validation_alias: str | None = None,
     **_: Any,
 ) -> _FieldInfo:
     return _FieldInfo(
         default=default,
         default_factory=default_factory,
+        alias=alias,
         validation_alias=validation_alias,
     )
 
@@ -67,9 +70,12 @@ class BaseModel:
     def __init__(self, **data: Any) -> None:
         annotations = self._model_annotations()
         for name, info in self.model_fields.items():
-            if name in data:
-                value = data[name]
-            else:
+            value = ...
+            for candidate in (name, info.alias, info.validation_alias):
+                if candidate and candidate in data:
+                    value = data[candidate]
+                    break
+            if value is ...:
                 value = info.get_default()
                 if value is ...:
                     raise TypeError(f"Missing required field: {name}")

--- a/tests/test_fastapi_testclient_websocket.py
+++ b/tests/test_fastapi_testclient_websocket.py
@@ -143,3 +143,54 @@ def test_pydantic_field_name_wins_over_aliases_when_multiple_keys_exist() -> Non
     payload = Payload(value="9", v="3", legacy_value="7")
 
     assert payload.value == 9
+
+
+def test_http_request_supports_embedded_body_aliases() -> None:
+    app = FastAPI(title="test", version="0")
+
+    class Payload(BaseModel):
+        value: int = Field(alias="v")
+
+    @app.post("/inspect-embed")
+    def inspect_embed(
+        count: int = Body(..., alias="c", embed=True),
+        payload: Payload = Body(..., embed=True),
+    ) -> dict[str, int]:
+        return {"count": count, "value": payload.value}
+
+    client = TestClient(app)
+    response = client.post(
+        "/inspect-embed",
+        json={"c": "5", "payload": {"v": "11"}},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"count": 5, "value": 11}
+
+
+def test_embedded_body_requires_wrapped_key() -> None:
+    app = FastAPI(title="test", version="0")
+
+    @app.post("/inspect-embed")
+    def inspect_embed(count: int = Body(..., embed=True)) -> dict[str, int]:
+        return {"count": count}
+
+    client = TestClient(app)
+    try:
+        client.post("/inspect-embed", json={"value": 4})
+    except TypeError as exc:
+        assert "Missing required body parameter: count" in str(exc)
+    else:
+        raise AssertionError("Expected missing embedded body key to fail")
+
+
+def test_pydantic_model_dump_supports_by_alias() -> None:
+    class Payload(BaseModel):
+        value: int = Field(alias="v")
+        model_config = {"populate_by_name": False}
+
+    payload = Payload(v="8")
+
+    assert payload.value == 8
+    assert payload.model_dump() == {"value": 8}
+    assert payload.model_dump(by_alias=True) == {"v": 8}

--- a/tests/test_fastapi_testclient_websocket.py
+++ b/tests/test_fastapi_testclient_websocket.py
@@ -1,5 +1,6 @@
-from fastapi import Cookie, FastAPI, Header, Query, WebSocket
+from fastapi import Body, Cookie, FastAPI, Header, Query, WebSocket
 from fastapi.testclient import TestClient
+from pydantic import BaseModel, Field
 
 
 def test_websocket_connect_parses_query_params() -> None:
@@ -100,3 +101,45 @@ def test_http_request_supports_query_header_and_cookie_aliases() -> None:
         "trace_id": "req-7",
         "session_token": "cookie-7",
     }
+
+
+def test_http_request_supports_body_alias_for_scalars_and_models() -> None:
+    app = FastAPI(title="test", version="0")
+
+    class Payload(BaseModel):
+        value: int = Field(alias="v")
+        legacy: int = Field(validation_alias="legacy_value")
+
+    @app.post("/inspect-body")
+    def inspect_body(
+        count: int = Body(..., alias="c"),
+        payload: Payload | None = None,
+    ) -> dict[str, int]:
+        assert payload is not None
+        return {
+            "count": count,
+            "value": payload.value,
+            "legacy": payload.legacy,
+        }
+
+    client = TestClient(app)
+    response = client.post(
+        "/inspect-body",
+        json={"c": "5", "v": "3", "legacy_value": "7"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "count": 5,
+        "value": 3,
+        "legacy": 7,
+    }
+
+
+def test_pydantic_field_name_wins_over_aliases_when_multiple_keys_exist() -> None:
+    class Payload(BaseModel):
+        value: int = Field(alias="v", validation_alias="legacy_value")
+
+    payload = Payload(value="9", v="3", legacy_value="7")
+
+    assert payload.value == 9


### PR DESCRIPTION
## Summary
- add a minimal `Body(...)` marker to the FastAPI shim and wire `embed=True` into request binding
- teach the Pydantic shim to resolve `Field(alias=...)` and `Field(validation_alias=...)`
- add small Pydantic parity improvements with `model_config.populate_by_name` and `model_dump(by_alias=True)`
- extend the test client body binder so scalar body aliases, embedded bodies, and optional body models resolve correctly
- add focused tests for alias precedence, embedded-body behavior, and alias-based dumping

## Why
- query, header, cookie, websocket, and fixture shim work was already in place, but body binding still lagged behind
- repo code already carried alias metadata in the Pydantic shim, yet request binding did not honor it
- `embed=True` was visible in API shape but not implemented, which could mislead future callers
- this closes a visible gap in FastAPI-like request handling without broadening scope into full framework emulation

## Scope
- In scope: `src/fastapi/*`, `src/pydantic.py`, and focused shim tests
- Out of scope: nested alias paths, advanced validators, full Pydantic v2 behavior parity

## Safety boundary
- Runtime or execution impact: low; changes are limited to test/runtime-compat shim surfaces
- Secret, credential, or permission impact: none
- Live-trading impact: none

## Validation
- local shim validation completed with `PYTHONPATH=src python -m pytest -q` in a fallback workspace
- observed result after the second wave patch: `11 passed` for the focused shim suite
- full repo checkout and end-to-end project test execution remain constrained in this environment by network/workspace access

## Rollback
- revert this branch or the resulting merge commit to restore the previous body-binding behavior
- risk if reverted: body alias support, embedded body handling, and new shim coverage disappear, while prior query/header/cookie behavior remains unchanged

## Docs impact
- [ ] `README.md`
- [ ] `docs/DEVELOPMENT.md`
- [ ] `docs/PRODUCTION_CHECKLIST.md`
- [ ] `docs/ACTIVE_EXECUTION_QUEUE.md`
- [x] No doc updates needed

## Merge aftercare
- [ ] Queue / blocker / next-step state updated
- [ ] Follow-up issue created when this PR is intentionally partial